### PR TITLE
Ignore frequency formatting changes

### DIFF
--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -175,6 +175,11 @@ class transformer(object):
             # Updated wording for non-expert-reviewed...
             value = value.replace("Not Yet Classified", "Not Yet Reviewed")
 
+        try:
+            value = float(value)
+        except ValueError:
+            pass
+
         return value
 
     def compareField(self, oldRow, newRow, field):

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -177,6 +177,7 @@ class transformer(object):
 
         try:
             value = float(value)
+            value = str(value)
         except ValueError:
             pass
 

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -4,7 +4,6 @@ import tempfile
 import csv
 import releaseDiff
 from os import path
-import pdb
 
 
 class TestStringMethods(unittest.TestCase):
@@ -421,6 +420,21 @@ class TestStringMethods(unittest.TestCase):
         diff = releaseDiff.diff_json
         self.assertEqual(diff, {})
         self.assertIsNone(change_type)
+
+    def test_catches_changed_numeric_values_after_normalization(self):
+        releaseDiff.added_data = self.added_data
+        releaseDiff.diff = self.diff
+        releaseDiff.diff_json = self.diff_json
+        variant = 'chr17:g.43049067:C>T'
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+
+        self.oldRow['Allele_frequency_ExAC'] = '9.841e-06'
+        self.newRow['Allele_frequency_ExAC'] = '9.841e-07'
+
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
+        diff = releaseDiff.diff_json
+        self.assertEqual(len(diff), 1)
+        self.assertIs(change_type, "changed_information")
 
     def test_catches_reordered_source_urls(self):
         releaseDiff.added_data = self.added_data

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -23,7 +23,9 @@ class TestStringMethods(unittest.TestCase):
                       'pyhgvs_Protein',
                       'Submitter_ClinVar',
                       'Source_URL',
-                      'Clinical_Significance_ClinVar'
+                      'Clinical_Significance_ClinVar',
+                      'Allele_frequency_ExAC',
+                      'EAS_Allele_frequency_1000_Genomes'
                      ]
         self.oldRow = {
                   'Pathogenicity_all': '',
@@ -35,7 +37,9 @@ class TestStringMethods(unittest.TestCase):
                   'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
                   'pyhgvs_Genomic_Coordinate_37': 'chr17:g.43049067:C>T',
                   'pyhgvs_Genomic_Coordinate_36': 'chr17:g.43049067:C>T',
-                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                  'pyhgvs_Protein': 'NP_009225.1:p.?',
+                  'Allele_frequency_ExAC': '9.841E-06',
+                  'EAS_Allele_frequency_1000_Genomes': '0'
                  }
         self.newRow = {
                   'Pathogenicity_all': '',
@@ -47,7 +51,9 @@ class TestStringMethods(unittest.TestCase):
                   'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
                   'pyhgvs_Genomic_Coordinate_37': 'chr17:g.43049067:C>T',
                   'pyhgvs_Genomic_Coordinate_36': 'chr17:g.43049067:C>T',
-                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                  'pyhgvs_Protein': 'NP_009225.1:p.?',
+                  'Allele_frequency_ExAC': '9.841E-06',
+                  'EAS_Allele_frequency_1000_Genomes': '0'
                  }
 
         self.test_dir = tempfile.mkdtemp()
@@ -402,6 +408,14 @@ class TestStringMethods(unittest.TestCase):
 
         self.oldRow["Submitter_ClinVar"] = "Consortium_of_Investigators_of_Modifiers_of_BRCA1/2_(CIMBA),_c/o_University_of_Cambridge"
         self.newRow["Submitter_ClinVar"] = "The_Consortium_of_Investigators_of_Modifiers_of_BRCA1/2_(CIMBA),c/o_University_of_Cambridge"
+
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
+        diff = releaseDiff.diff_json
+        self.assertEqual(diff, {})
+        self.assertIsNone(change_type)
+
+        self.newRow['EAS_Allele_frequency_1000_Genomes'] = '0.0'
+        self.newRow['Allele_frequency_ExAC'] = '9.841e-06'
 
         change_type = v1v2.compareRow(self.oldRow, self.newRow)
         diff = releaseDiff.diff_json

--- a/website/README.md
+++ b/website/README.md
@@ -68,7 +68,7 @@ This process will add an additional release to the database and rebuild the word
 
  * Create a new directory at `brca-exchange/website/django/data/resources/releases/release-{MM-DD-YY}` that contains `built_with_change_types.tsv`, `removed.tsv`, and `version.json` from the desired pipeline output.
  * Add the archive of the release (e.g. `release-10-06-16.tar.gz`) to `brca-exchange/website/django/uploads/releases/` so the archive can be downloaded by users.
- * Run `./manage.py addrelease ./data/resources/releases/release-{MM-DD-YY}/built_with_change_types.tsv ./data/resources/releases/release-{MM-DD-YY}/version.json ./data/resources/releases/release-{MM-DD-YY}/removed.tsv` to add new data to the database, rebuild the words table, and generate a new release.
+ * Run `./manage.py addrelease ./data/resources/releases/release-{MM-DD-YY}/built_with_change_types.tsv ./data/resources/releases/release-{MM-DD-YY}/reports.tsv ./data/resources/releases/release-{MM-DD-YY}/version.json ./data/resources/releases/release-{MM-DD-YY}/removed.tsv ./data/resources/releases/release-{MM-DD-YY}/diff.json` to add new data to the database, rebuild the words table, and generate a new release.
 
 ## How to add/approve new users on the community page
 * Go to http://brcaexchange.org/backend/admin/ and follow necessary steps.


### PR DESCRIPTION
This update tells the diff algorithm to ignore all changes to number formats -- i.e. if a number format changes but it's value is still equivalent, it will be ignored in the diff.