### PR TITLE
store filter and column selections in local storage, fix table layout…

### DIFF
--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -101,11 +101,15 @@ var DataTable = React.createClass({
         this.fetch(this.state);
     },
     getInitialState: function () {
+        let filterValues = JSON.parse(localStorage.getItem('filterValues'));
+        if (filterValues === null || filterValues === undefined) {
+            filterValues = {};
+        }
         return mergeState({
             data: [],
             lollipopOpen: false,
             filtersOpen: false,
-            filterValues: {},
+            filterValues: filterValues,
             search: '',
             columnSelection: this.props.columnSelection,
             sourceSelection: this.props.sourceSelection,
@@ -125,8 +129,10 @@ var DataTable = React.createClass({
         this.setState({windowWidth: window.innerWidth});
     },
     setFilters: function (obj) {
-        var {filterValues} = this.state,
+        let {filterValues} = this.state,
             newFilterValues = merge(filterValues, obj);
+
+        localStorage.setItem('filterValues', JSON.stringify(newFilterValues));
 
         this.setStateFetch({
           filterValues: newFilterValues,
@@ -134,6 +140,7 @@ var DataTable = React.createClass({
         });
     },
     clearFilters: function () {
+        localStorage.setItem('filterValues', null);
         // Reset release and changetype filters
         this.setStateFetch({
             release: undefined,

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -411,7 +411,6 @@ div#main {
 
 @media only screen and (min-width: 768px) {
     #data-table-container table {
-        table-layout: fixed;
         min-width: 612px;
     }
 

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -42,7 +42,7 @@ var databaseKey = require('../databaseKey');
 var {Grid, Col, Row, Table, Button, Modal, Panel, Glyphicon} = require('react-bootstrap');
 
 /* FAISAL: added 'groups' collection that specifies how to map columns to higher-level groups */
-var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups} = require('./VariantTable');
+var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups, defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTable');
 var {Signup} = require('./Signup');
 var {Signin, ResetPassword} = require('./Signin');
 var {ConfirmEmail} = require('./ConfirmEmail');
@@ -209,40 +209,27 @@ function toNumber(v) {
 }
 
 function databaseParams(paramsIn) {
-    var {filter, filterValue, hide, hideSources, excludeSources, orderBy, order, search = '', changeTypes} = paramsIn;
+    var {orderBy, order, search = '', changeTypes} = paramsIn;
     var numParams = _.mapObject(_.pick(paramsIn, 'page', 'pageLength', 'release'), toNumber);
     var sortBy = {prop: orderBy, order};
-    var columnSelection = _.object(hide, _.map(hide, _.constant(false)));
-    var sourceSelection = {..._.object(hideSources, _.map(hideSources, _.constant(0))),
-                           ..._.object(excludeSources, _.map(excludeSources, _.constant(-1)))};
-    var filterValues = _.object(filter, filterValue);
-    return {changeTypes, search, sortBy, columnSelection, sourceSelection, filterValues, hide, ...numParams};
+    return {changeTypes, search, sortBy, ...numParams};
 }
 
 var transpose = a => _.zip.apply(_, a);
 
-function urlFromDatabase(state) {
+function urlFromDatabase(state, mode) {
     // Need to diff from defaults. The defaults are in DataTable.
     // We could keep the defaults here, or in a different module.
-    var {release, changeTypes, columnSelection, filterValues, sourceSelection,
-            search, page, pageLength, sortBy: {prop, order}} = state;
-    var hide = _.keys(_.pick(columnSelection, v => v === false));
-    var hideSources = _.keys(_.pick(sourceSelection, v => v === 0));
-    var excludeSources = _.keys(_.pick(sourceSelection, v => v === -1));
-    var [filter, filterValue] = transpose(_.pairs(_.pick(filterValues, v => v === true)));
+    var {release, changeTypes, search, page, pageLength,
+        sortBy: {prop, order}} = state;
     return _.pick({
         release,
         changeTypes,
         search: search === '' ? null : backend.trimSearchTerm(search),
-        filter,
-        filterValue,
         page: page === 0 ? null : page,
         pageLength: pageLength === 20 ? null : pageLength,
         orderBy: prop,
-        order,
-        hideSources: hideSources,
-        excludeSources: excludeSources,
-        hide: hide.length === 0 ? null : hide
+        order
     }, v => v != null);
 
 }
@@ -295,7 +282,10 @@ var Database = React.createClass({
                 d3TipDiv[0].style.opacity = '0';
                 d3TipDiv[0].style.pointerEvents = 'none';
             }
-            this.transitionTo('/variants', {}, urlFromDatabase(state));
+            if (this.state.showModal != true) {
+                // Don't change url if modal is open -- user is still deciding whether to change modes.
+                this.transitionTo('/variants', {}, urlFromDatabase(state, this.props.mode));
+            }
         }
     },
     toggleMode: function () {
@@ -397,8 +387,8 @@ const GroupHelpButton = React.createClass({
 // all data, otherwise go straight to all data. Finally, if key is not found, replace
 // _ with space in the key and return that.
 function getDisplayName(key) {
-    var researchMode = (localStorage.getItem("research-mode") === 'true');
-    var displayName;
+    const researchMode = (localStorage.getItem("research-mode") === 'true');
+    let displayName;
     if (!researchMode) {
         displayName = columns.find(e => e.prop === key);
         displayName = displayName && displayName.title;

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -42,7 +42,7 @@ var databaseKey = require('../databaseKey');
 var {Grid, Col, Row, Table, Button, Modal, Panel, Glyphicon} = require('react-bootstrap');
 
 /* FAISAL: added 'groups' collection that specifies how to map columns to higher-level groups */
-var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups, defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTable');
+var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups} = require('./VariantTable');
 var {Signup} = require('./Signup');
 var {Signin, ResetPassword} = require('./Signin');
 var {ConfirmEmail} = require('./ConfirmEmail');
@@ -215,9 +215,7 @@ function databaseParams(paramsIn) {
     return {changeTypes, search, sortBy, ...numParams};
 }
 
-var transpose = a => _.zip.apply(_, a);
-
-function urlFromDatabase(state, mode) {
+function urlFromDatabase(state) {
     // Need to diff from defaults. The defaults are in DataTable.
     // We could keep the defaults here, or in a different module.
     var {release, changeTypes, search, page, pageLength,
@@ -282,9 +280,9 @@ var Database = React.createClass({
                 d3TipDiv[0].style.opacity = '0';
                 d3TipDiv[0].style.pointerEvents = 'none';
             }
-            if (this.state.showModal != true) {
+            if (this.state.showModal !== true) {
                 // Don't change url if modal is open -- user is still deciding whether to change modes.
-                this.transitionTo('/variants', {}, urlFromDatabase(state, this.props.mode));
+                this.transitionTo('/variants', {}, urlFromDatabase(state));
             }
         }
     },


### PR DESCRIPTION
This PR changes a few things and requires further review before merge.

1. Introduces local storage to manage column, filter, and source selections for the variant table.
2. Ignores query string when determining column, filter and source selections.
3. Fixes a table layout bug when adding new columns to the variant table.

Outstanding questions:

1. Should local storage override query parameters?
2. Should filters be persistent in the same way column selections are persistent? Furthermore, should they persist between portals?


