### PR TITLE
separate column/source filters from pathogenicity/gene filters, close…

### DIFF
--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -218,7 +218,7 @@ var DataTable = React.createClass({
     render: function () {
         var {release, changeTypes, filterValues, filtersOpen, advancedFiltersOpen, lollipopOpen, search, data, columnSelection,
             page, totalPages, count, synonyms, error} = this.state;
-        var {columns, filterColumns, className, advancedFilters, downloadButton, lollipopButton, mode} = this.props;
+        var {columns, filterColumns, className, advancedFilters, filters, downloadButton, lollipopButton, mode} = this.props;
         var renderColumns = _.filter(columns, c => columnSelection[c.prop]);
         var filterFormEls = _.map(filterColumns, ({name, prop, values}) =>
             <SelectField onChange={v => this.setFilters({[prop]: filterAny(v)})}
@@ -255,14 +255,14 @@ var DataTable = React.createClass({
                                 onClick={this.toggleFilters}>{(filtersOpen ? 'Hide' : 'Show' ) + ' Filters'}
                         </Button>
                         {mode === "research_mode" && <Button className="btn-sm rgt-buffer"
-                                onClick={this.toggleAdvancedFilters}>{(advancedFiltersOpen ? 'Hide' : 'Show' ) + ' Advanced Filters'}
+                                onClick={this.toggleAdvancedFilters}>{(advancedFiltersOpen ? 'Hide' : 'Show' ) + ' Column Selectors'}
                         </Button>}
                         {lollipopButton(this.toggleLollipop, lollipopOpen)}
                     </Col>
                 </Row>
                 <Row id="filters">
                     <Col sm={10} smOffset={1}>
-                        {filtersOpen && <div className='form-inline'>{filterFormEls}</div>}
+                        {filtersOpen && <div className='form-inline'>{filterFormEls}{filters}</div>}
                         {advancedFiltersOpen && mode === "research_mode" && <div className='form-inline'>
                             {advancedFilters}
                         </div>}

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -72,7 +72,7 @@ var DataTable = React.createClass({
     shouldComponentUpdate: function (nextProps, nextState) {
         return (
             this.state.filtersOpen !== nextState.filtersOpen ||
-            this.state.advancedFiltersOpen !== nextState.advancedFiltersOpen ||
+            this.state.columnSelectorsOpen !== nextState.columnSelectorsOpen ||
             this.state.lollipopOpen !== nextState.lollipopOpen ||
             this.state.page !== nextState.page ||
             this.state.count !== nextState.count ||
@@ -106,7 +106,7 @@ var DataTable = React.createClass({
             data: [],
             lollipopOpen: false,
             filtersOpen: false,
-            advancedFiltersOpen: false,
+            columnSelectorsOpen: false,
             filterValues: {},
             search: '',
             columnSelection: this.props.columnSelection,
@@ -196,8 +196,8 @@ var DataTable = React.createClass({
     toggleFilters: function () {
         this.setState({filtersOpen: !this.state.filtersOpen});
     },
-    toggleAdvancedFilters: function() {
-        this.setState({advancedFiltersOpen: !this.state.advancedFiltersOpen});
+    toggleColumnSelectors: function() {
+        this.setState({columnSelectorsOpen: !this.state.columnSelectorsOpen});
     },
     showDeleted: function () {
         this.setStateFetch({showDeleted: true});
@@ -216,9 +216,9 @@ var DataTable = React.createClass({
         this.setStateFetch({page: newPage, pageLength: length});
     },
     render: function () {
-        var {release, changeTypes, filterValues, filtersOpen, advancedFiltersOpen, lollipopOpen, search, data, columnSelection,
+        var {release, changeTypes, filterValues, filtersOpen, columnSelectorsOpen, lollipopOpen, search, data, columnSelection,
             page, totalPages, count, synonyms, error} = this.state;
-        var {columns, filterColumns, className, advancedFilters, filters, downloadButton, lollipopButton, mode} = this.props;
+        var {columns, filterColumns, className, columnSelectors, filters, downloadButton, lollipopButton, mode} = this.props;
         var renderColumns = _.filter(columns, c => columnSelection[c.prop]);
         var filterFormEls = _.map(filterColumns, ({name, prop, values}) =>
             <SelectField onChange={v => this.setFilters({[prop]: filterAny(v)})}
@@ -255,7 +255,7 @@ var DataTable = React.createClass({
                                 onClick={this.toggleFilters}>{(filtersOpen ? 'Hide' : 'Show' ) + ' Filters'}
                         </Button>
                         {mode === "research_mode" && <Button className="btn-sm rgt-buffer"
-                                onClick={this.toggleAdvancedFilters}>{(advancedFiltersOpen ? 'Hide' : 'Show' ) + ' Column Selectors'}
+                                onClick={this.toggleColumnSelectors}>{(columnSelectorsOpen ? 'Hide' : 'Show' ) + ' Column Selectors'}
                         </Button>}
                         {lollipopButton(this.toggleLollipop, lollipopOpen)}
                     </Col>
@@ -263,8 +263,8 @@ var DataTable = React.createClass({
                 <Row id="filters">
                     <Col sm={10} smOffset={1}>
                         {filtersOpen && <div className='form-inline'>{filterFormEls}{filters}</div>}
-                        {advancedFiltersOpen && mode === "research_mode" && <div className='form-inline'>
-                            {advancedFilters}
+                        {columnSelectorsOpen && mode === "research_mode" && <div className='form-inline'>
+                            {columnSelectors}
                         </div>}
                     </Col>
                 </Row>

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -72,6 +72,7 @@ var DataTable = React.createClass({
     shouldComponentUpdate: function (nextProps, nextState) {
         return (
             this.state.filtersOpen !== nextState.filtersOpen ||
+            this.state.advancedFiltersOpen !== nextState.advancedFiltersOpen ||
             this.state.lollipopOpen !== nextState.lollipopOpen ||
             this.state.page !== nextState.page ||
             this.state.count !== nextState.count ||
@@ -105,6 +106,7 @@ var DataTable = React.createClass({
             data: [],
             lollipopOpen: false,
             filtersOpen: false,
+            advancedFiltersOpen: false,
             filterValues: {},
             search: '',
             columnSelection: this.props.columnSelection,
@@ -194,6 +196,9 @@ var DataTable = React.createClass({
     toggleFilters: function () {
         this.setState({filtersOpen: !this.state.filtersOpen});
     },
+    toggleAdvancedFilters: function() {
+        this.setState({advancedFiltersOpen: !this.state.advancedFiltersOpen});
+    },
     showDeleted: function () {
         this.setStateFetch({showDeleted: true});
     },
@@ -211,9 +216,9 @@ var DataTable = React.createClass({
         this.setStateFetch({page: newPage, pageLength: length});
     },
     render: function () {
-        var {release, changeTypes, filterValues, filtersOpen, lollipopOpen, search, data, columnSelection,
+        var {release, changeTypes, filterValues, filtersOpen, advancedFiltersOpen, lollipopOpen, search, data, columnSelection,
             page, totalPages, count, synonyms, error} = this.state;
-        var {columns, filterColumns, className, advancedFilters, downloadButton, lollipopButton} = this.props;
+        var {columns, filterColumns, className, advancedFilters, downloadButton, lollipopButton, mode} = this.props;
         var renderColumns = _.filter(columns, c => columnSelection[c.prop]);
         var filterFormEls = _.map(filterColumns, ({name, prop, values}) =>
             <SelectField onChange={v => this.setFilters({[prop]: filterAny(v)})}
@@ -249,13 +254,16 @@ var DataTable = React.createClass({
                         <Button className="btn-sm rgt-buffer"
                                 onClick={this.toggleFilters}>{(filtersOpen ? 'Hide' : 'Show' ) + ' Filters'}
                         </Button>
+                        {mode === "research_mode" && <Button className="btn-sm rgt-buffer"
+                                onClick={this.toggleAdvancedFilters}>{(advancedFiltersOpen ? 'Hide' : 'Show' ) + ' Advanced Filters'}
+                        </Button>}
                         {lollipopButton(this.toggleLollipop, lollipopOpen)}
                     </Col>
                 </Row>
                 <Row id="filters">
                     <Col sm={10} smOffset={1}>
                         {filtersOpen && <div className='form-inline'>{filterFormEls}</div>}
-                        {filtersOpen && <div className='form-inline'>
+                        {advancedFiltersOpen && mode === "research_mode" && <div className='form-inline'>
                             {advancedFilters}
                         </div>}
                     </Col>

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -477,7 +477,7 @@ var hasSelection = () => !(window.getSelection && window.getSelection().isCollap
 var Table = React.createClass({
     mixins: [PureRenderMixin],
     render: function () {
-        var {data, onHeaderClick, onRowClick, hiddenSources, ...opts} = this.props;
+        var {data, onHeaderClick, onRowClick, hiddenSources, mode, ...opts} = this.props;
         return (
             <DataTable
                 ref='table'
@@ -491,7 +491,8 @@ var Table = React.createClass({
                 initialData={data}
                 initialPageLength={20}
                 initialSortBy={{prop: 'Gene_Symbol', order: 'descending'}}
-                pageLengthOptions={[ 20, 50, 100 ]}/>
+                pageLengthOptions={[ 20, 50, 100 ]}
+                mode={mode}/>
         );
     }
 });

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -531,7 +531,7 @@ var ResearchVariantTableSupplier = function (Component) {
                 <ColumnCheckbox onChange={() => this.toggleColumns(prop)} key={prop} label={prop} title={title}
                                 initialCheck={columnSelection}/>);
         },
-        getAdvancedFilters() {
+        getColumnSelectors() {
             var filterFormSubCols = _.map(subColumns, ({subColTitle, subColList}) =>
                 <Col sm={6} md={4} key={subColTitle}>
                     <Panel header={subColTitle}>
@@ -581,7 +581,7 @@ var ResearchVariantTableSupplier = function (Component) {
                 <Component
                     {...this.props}
                     columns={this.getColumns()}
-                    advancedFilters={this.getAdvancedFilters()}
+                    columnSelectors={this.getColumnSelectors()}
                     filters={this.getFilters()}
                     sourceSelection={sourceSelection}
                     columnSelection={columnSelection}

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -532,14 +532,6 @@ var ResearchVariantTableSupplier = function (Component) {
                                 initialCheck={columnSelection}/>);
         },
         getAdvancedFilters() {
-            var sourceCheckboxes = _.map(this.state.sourceSelection, (value, name) =>
-                <Col sm={6} md={3} key={name}>
-                    <Input type="checkbox"
-                        onChange={v => this.setSource(name, v)}
-                        label={name.substring(11).replace(/_/g, " ")} // eg "Variant_in_1000_Genomes" => "1000 Genomes"
-                        checked={value > 0}/>
-                </Col>
-            );
             var filterFormSubCols = _.map(subColumns, ({subColTitle, subColList}) =>
                 <Col sm={6} md={4} key={subColTitle}>
                     <Panel header={subColTitle}>
@@ -548,11 +540,23 @@ var ResearchVariantTableSupplier = function (Component) {
                 </Col>
             );
             return (<label className='control-label'>
-                <Panel className="top-buffer" header="Source Selection">
-                    {sourceCheckboxes}
-                </Panel>
                 <Panel header="Column Selection">
                     {filterFormSubCols}
+                </Panel>
+            </label>);
+        },
+        getFilters: function() {
+            var sourceCheckboxes = _.map(this.state.sourceSelection, (value, name) =>
+                <Col sm={6} md={3} key={name}>
+                    <Input type="checkbox"
+                        onChange={v => this.setSource(name, v)}
+                        label={name.substring(11).replace(/_/g, " ")} // eg "Variant_in_1000_Genomes" => "1000 Genomes"
+                        checked={value > 0}/>
+                </Col>
+            );
+            return (<label className='control-label'>
+                <Panel className="top-buffer" header="Source Selection">
+                    {sourceCheckboxes}
                 </Panel>
             </label>);
         },
@@ -578,6 +582,7 @@ var ResearchVariantTableSupplier = function (Component) {
                     {...this.props}
                     columns={this.getColumns()}
                     advancedFilters={this.getAdvancedFilters()}
+                    filters={this.getFilters()}
                     sourceSelection={sourceSelection}
                     columnSelection={columnSelection}
                     downloadButton={this.getDownloadButton}

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -465,6 +465,10 @@ html {
     margin-right: 1em;
 }
 
+#filters .form-inline {
+    margin-bottom: 1em;
+}
+
 /* Hide lollipop chart toggle if screen is too small to display chart */
 @media only screen and (max-width: 991px) {
     #lollipop-chart-toggle {

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -320,7 +320,8 @@ var Database = React.createClass({
 					onToggleMode={this}
 					keys={databaseKey}
 					onHeaderClick={this.showHelp}
-					onRowClick={this.showVariant}/>);
+					onRowClick={this.showVariant}
+                    mode={this.props.mode}/>);
             message = this.renderMessage(content.pages.variantsResearch);
         } else {
             params.columnSelection = {};
@@ -336,7 +337,8 @@ var Database = React.createClass({
 					onToggleMode={this}
 					keys={databaseKey}
 					onHeaderClick={this.showHelp}
-					onRowClick={this.showVariant}/>);
+					onRowClick={this.showVariant}
+                    mode={this.props.mode}/>);
             message = this.renderMessage(content.pages.variantsDefault);
         }
         return (


### PR DESCRIPTION
The following changes are introduced in this PR:

`Show Filters` previously showed all filters and column selectors. Now, it only shows pathogenicity and gene filters. `Show Advanced Filters` shows source filters and column selectors.

A couple things need clarification before merge:

- The wording of the buttons `Show Filters`, `Show Advanced Filters` and `Clear Filters` is confusing.

- Should source filters and column selectors be separated or grouped together like they are in this PR?

- `Clear Filters` only clears the release and change_type filters, but does not clear pathogenicity/source/column/gene filters. It's actually not even accessible unless a release or change_type filter is in use (activated by selecting from a previous release on the `Previous Data Releases` page).
