### PR TITLE
registration confirmation message

### DIFF
--- a/website/js/Community.js
+++ b/website/js/Community.js
@@ -72,7 +72,7 @@ var Community = React.createClass({
         if (queryParams.registrationSuccess === "true") {
             message = (
 				<div className="alert alert-success">
-					<p>Thanks for signing up. We have sent you an email with a confirmation link to complete your registration.</p>
+					<p>Thanks for signing up. We have sent you an email with a confirmation link to complete your registration. After you complete your registration our administrator will confirm your profile and it will appear on the Community Pages.</p>
 				</div>);
         } else if (queryParams.updateSuccess === "true") {
             message = (


### PR DESCRIPTION
closes #76 

The formatting for the message is a bit awkward now. I think this would look good:

<img width="1431" alt="screen shot 2017-05-07 at 7 58 20 pm" src="https://cloud.githubusercontent.com/assets/5573574/25788954/c9a8831e-3361-11e7-9979-21f3cc47a788.png">
