### PR TITLE
Community page cleanups #478

### DIFF
--- a/website/js/Community.js
+++ b/website/js/Community.js
@@ -160,6 +160,10 @@ var Community = React.createClass({
                 </Row>
                 <Row>
                     <Col sm={10} smOffset={1} md={8} mdOffset={2}>
+                        <span style={{verticalAlign: 'middle', display: 'inline-block'}}>
+                        {(this.state.page * this.state.pageLength) + 1}-{Math.min((this.state.page + 1) * this.state.pageLength, this.state.count)} out of {this.state.count} members
+                        </span>
+
                         <Pagination
                             className="pagination pull-right-sm"
                             currentPage={page}

--- a/website/js/Community.js
+++ b/website/js/Community.js
@@ -122,7 +122,7 @@ var Community = React.createClass({
                     </Col>
                 </Row>
                 <Row>
-                    <Col>
+                    <Col md={8} mdOffset={2} sm={10} smOffset={1}>
                         <CommunityMap onFilterRole={this.onFilterRole} search={this.state.search}/>
                     </Col>
                 </Row>

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -553,8 +553,8 @@ th[role='columnheader'] .help, .help-target .help {
 
 
 #communityMap {
-    width: 500px;
-    height: 250px;
+    width: 100%;
+    height: 300px;
     margin: 20px auto 20px auto;
 }
 


### PR DESCRIPTION
Community page map now scales horizontally to match the size of the user-list column and is slightly taller than before (300px vs. 250px.) Added an indicator of the currently-visible and total number of members on the bottom-left of the user-list.