### PR TITLE
Save column filter selections

### DIFF
--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -101,11 +101,15 @@ var DataTable = React.createClass({
         this.fetch(this.state);
     },
     getInitialState: function () {
+        let filterValues = JSON.parse(localStorage.getItem('filterValues'));
+        if (filterValues === null || filterValues === undefined) {
+            filterValues = {};
+        }
         return mergeState({
             data: [],
             lollipopOpen: false,
             filtersOpen: false,
-            filterValues: {},
+            filterValues: filterValues,
             search: '',
             columnSelection: this.props.columnSelection,
             sourceSelection: this.props.sourceSelection,
@@ -125,8 +129,10 @@ var DataTable = React.createClass({
         this.setState({windowWidth: window.innerWidth});
     },
     setFilters: function (obj) {
-        var {filterValues} = this.state,
+        let {filterValues} = this.state,
             newFilterValues = merge(filterValues, obj);
+
+        localStorage.setItem('filterValues', JSON.stringify(newFilterValues));
 
         this.setStateFetch({
           filterValues: newFilterValues,
@@ -134,6 +140,7 @@ var DataTable = React.createClass({
         });
     },
     clearFilters: function () {
+        localStorage.setItem('filterValues', null);
         // Reset release and changetype filters
         this.setStateFetch({
             release: undefined,

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -33,6 +33,20 @@ function setPages({data, count, deletedCount, synonyms}, pageLength) { //eslint-
     };
 }
 
+function clean(obj) {
+    // Removes all empty values from object.
+    var propNames = Object.getOwnPropertyNames(obj);
+    for (var i = 0; i < propNames.length; i++) {
+        let propName = propNames[i];
+        let val = obj[propName];
+        if ((typeof val === 'string' || val instanceof String) && val.trim() === '') {
+            delete obj[propName];
+        } else if (val === null || val === undefined) {
+            delete obj[propName];
+        }
+    }
+}
+
 // Wrap Table with a version having PureRenderMixin
 var FastTable = React.createClass({
     mixins: [PureRenderMixin],
@@ -132,8 +146,9 @@ var DataTable = React.createClass({
         this.setState({windowWidth: window.innerWidth});
     },
     setFilters: function (obj) {
-        let {filterValues} = this.state,
-            newFilterValues = merge(filterValues, obj);
+        let {filterValues} = this.state;
+        let newFilterValues = merge(filterValues, obj);
+        clean(newFilterValues);
 
         localStorage.setItem('filterValues', JSON.stringify(newFilterValues));
 

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -142,14 +142,6 @@ var DataTable = React.createClass({
           page: 0
         });
     },
-    clearFilters: function () {
-        localStorage.setItem('filterValues', null);
-        // Reset release and changetype filters
-        this.setStateFetch({
-            release: undefined,
-            changeTypes: undefined,
-        });
-    },
     createDownload: function () {
         var {release, changeTypes, search, sortBy, filterValues, columnSelection, sourceSelection} = this.state;
         return this.props.url(merge({
@@ -225,6 +217,29 @@ var DataTable = React.createClass({
 
         this.setStateFetch({page: newPage, pageLength: length});
     },
+    restoreDefaults: function() {
+        // Clears local storage, resets filters/columns/sources/releases/changetypes,
+        // and resets url to /variants (parent method uses a flag to ensure query params remain empty).
+        delete localStorage.columnSelection;
+        delete localStorage.filterValues;
+        delete localStorage.sourceSelection;
+        let that = this;
+        if (this.state.mode === 'default') {
+            this.props.expertVariantTableRestoreDefaults(function() {
+                that.setState({filterValues: {},
+                               release: undefined,
+                               changeTypes: undefined
+                             });
+            });
+        } else {
+            this.props.researchVariantTableRestoreDefaults(function() {
+                that.setState({filterValues: {},
+                               release: undefined,
+                               changeTypes: undefined
+                             });
+            });
+        }
+    },
     render: function () {
         var {release, changeTypes, filterValues, filtersOpen, columnSelectorsOpen, lollipopOpen, search, data, columnSelection,
             page, totalPages, count, synonyms, error} = this.state;
@@ -267,6 +282,9 @@ var DataTable = React.createClass({
                         {mode === "research_mode" && <Button className="btn-sm rgt-buffer"
                                 onClick={this.toggleColumnSelectors}>{(columnSelectorsOpen ? 'Hide' : 'Show' ) + ' Column Selectors'}
                         </Button>}
+                        <Button className="btn-sm rgt-buffer"
+                                onClick={this.restoreDefaults}>Restore Defaults
+                        </Button>
                         {lollipopButton(this.toggleLollipop, lollipopOpen)}
                     </Col>
                 </Row>
@@ -294,10 +312,6 @@ var DataTable = React.createClass({
                                     {release ? 'in release ' + release : ''} {}
                                     {synonyms ? 'of which ' + synonyms + ' matched on synonyms' : ''}
                                 </label>
-                                {release || changeString ?
-                                    <Button className="btn-sm rgt-buffer"
-                                        onClick={this.clearFilters}>Clear Filters
-                                    </Button> : ''} {}
                                 {downloadButton(this.createDownload)}
                             </div>
                         </div>

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -33,20 +33,6 @@ function setPages({data, count, deletedCount, synonyms}, pageLength) { //eslint-
     };
 }
 
-function clean(obj) {
-    // Removes all empty values from object.
-    var propNames = Object.getOwnPropertyNames(obj);
-    for (var i = 0; i < propNames.length; i++) {
-        let propName = propNames[i];
-        let val = obj[propName];
-        if ((typeof val === 'string' || val instanceof String) && val.trim() === '') {
-            delete obj[propName];
-        } else if (val === null || val === undefined) {
-            delete obj[propName];
-        }
-    }
-}
-
 // Wrap Table with a version having PureRenderMixin
 var FastTable = React.createClass({
     mixins: [PureRenderMixin],
@@ -148,7 +134,6 @@ var DataTable = React.createClass({
     setFilters: function (obj) {
         let {filterValues} = this.state;
         let newFilterValues = merge(filterValues, obj);
-        clean(newFilterValues);
 
         localStorage.setItem('filterValues', JSON.stringify(newFilterValues));
 

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -113,6 +113,7 @@ var DataTable = React.createClass({
             filterValues: filterValues,
             columnSelectorsOpen: false,
             search: '',
+            mode: this.props.mode,
             columnSelection: this.props.columnSelection,
             sourceSelection: this.props.sourceSelection,
             pageLength: 20,
@@ -175,7 +176,8 @@ var DataTable = React.createClass({
     },
     fetch: function (state) {
         var {pageLength, search, page, sortBy,
-            filterValues, columnSelection, sourceSelection, release, changeTypes, showDeleted} = state;
+            filterValues, columnSelection, sourceSelection,
+            release, changeTypes, showDeleted, mode} = state;
         this.fetchq.onNext(merge({
             release,
             changeTypes,
@@ -184,6 +186,7 @@ var DataTable = React.createClass({
             page,
             sortBy,
             search,
+            mode,
             searchColumn: _.keys(_.pick(columnSelection, v => v)),
             include: _.keys(_.pick(sourceSelection, v => v === 1)),
             exclude: _.keys(_.pick(sourceSelection, v => v === -1)),

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -464,13 +464,13 @@ var ResearchVariantTableSupplier = function (Component) {
                     c => _.contains(this.getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
                 );
             }
-            let selectedSources = JSON.parse(localStorage.getItem('selectedSources'));
+            let selectedSources = JSON.parse(localStorage.getItem('sourceSelection'));
             if (selectedSources === null || selectedSources === undefined) {
                 selectedSources = allSources;
             }
 
             return {
-                sourceSelection: {...allSources},
+                sourceSelection: {...selectedSources},
                 columnSelection: {...selectedColumns}
             };
         },

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -36,7 +36,7 @@ function renderCell(val) {
 
 var filterColumns = [
     {name: 'Gene', prop: 'Gene_Symbol', values: ['BRCA1', 'BRCA2']},
-    {name: 'Pathogenicity', prop: 'Pathogenicity_expert', values: ['Pathogenic', 'Benign / Little Clinical Significance', 'Not Yet Classified']}
+    {name: 'Pathogenicity', prop: 'Pathogenicity_expert', values: ['Pathogenic', 'Benign / Little Clinical Significance', 'Not Yet Reviewed']}
 ];
 
 const expertModeGroups = [

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -508,7 +508,7 @@ var ResearchVariantTableSupplier = function (Component) {
                     selectedColumns = lsSelectedColumns;
                 }
                 const lsSelectedSources = JSON.parse(localStorage.getItem('sourceSelection'));
-                if (lsSelectedSources !== null || lsSelectedSources !== undefined) {
+                if (lsSelectedSources !== null && lsSelectedSources !== undefined) {
                     selectedSources = lsSelectedSources;
                 }
             }

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -471,16 +471,16 @@ var ResearchVariantTableSupplier = function (Component) {
                 2. Local Storage
                 3. Default settings
 
-            To accomplish this, first set selections to default. Then update selections
-            according to query params if present. If no query params are present, update
-            according to local storage if present. If neither query params nor local storage
-            specify changes, the default settings persist.
+            To accomplish this, first set all column selections to true and all filters off.
+            Then, update selections according to query params if present. If no query params
+            are present, update according to local storage if present. If neither query params
+            nor local storage specify changes, use default settings.
             */
 
-            // Set defaults.
-            var selectedColumns = _.object(_.map(this.getColumns(),
-                c => _.contains(getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
-            );
+            // Start with all columns set to true and data showing from all sources.
+            var selectedColumns = selectedColumns = _.object(_.map(this.getColumns(),
+                                    c => [c.prop, true])
+                                );
             var selectedSources = getAllSources();
 
             // Get query params.
@@ -506,6 +506,11 @@ var ResearchVariantTableSupplier = function (Component) {
                 const lsSelectedColumns = JSON.parse(localStorage.getItem('columnSelection'));
                 if (lsSelectedColumns !== null && lsSelectedColumns !== undefined) {
                     selectedColumns = lsSelectedColumns;
+                } else {
+                    // If no query params and no local storage, use default settings.
+                    selectedColumns = _.object(_.map(this.getColumns(),
+                        c => _.contains(getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
+                    );
                 }
                 const lsSelectedSources = JSON.parse(localStorage.getItem('sourceSelection'));
                 if (lsSelectedSources !== null && lsSelectedSources !== undefined) {

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -582,7 +582,7 @@ var ResearchVariantTableSupplier = function (Component) {
             return researchModeColumns;
         },
         getDefaultColumnSelections: function() {
-            return _.object(_.map(columns,
+            return _.object(_.map(researchModeColumns,
                 c => _.contains(getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
             );
         },

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -508,9 +508,7 @@ var ResearchVariantTableSupplier = function (Component) {
                     selectedColumns = lsSelectedColumns;
                 } else {
                     // If no query params and no local storage, use default settings.
-                    selectedColumns = _.object(_.map(this.getColumns(),
-                        c => _.contains(getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
-                    );
+                    selectedColumns = this.getDefaultColumnSelections();
                 }
                 const lsSelectedSources = JSON.parse(localStorage.getItem('sourceSelection'));
                 if (lsSelectedSources !== null && lsSelectedSources !== undefined) {
@@ -583,17 +581,33 @@ var ResearchVariantTableSupplier = function (Component) {
         getColumns: function () {
             return researchModeColumns;
         },
+        getDefaultColumnSelections: function() {
+            return _.object(_.map(columns,
+                c => _.contains(getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
+            );
+        },
+        getDefaultSourceSelections: function() {
+            return getAllSources();
+        },
+        researchVariantTableRestoreDefaults: function(callback) {
+            const columnSelection = this.getDefaultColumnSelections();
+            const sourceSelection = this.getDefaultSourceSelections();
+            this.setState({columnSelection: columnSelection,
+                           sourceSelection: sourceSelection},
+                           function() {
+                                this.props.restoreDefaults(callback);
+                           });
+        },
         render: function () {
-            const sourceSelection = this.state.sourceSelection;
-            const columnSelection = this.state.columnSelection;
             return (
                 <Component
                     {...this.props}
+                    researchVariantTableRestoreDefaults={this.researchVariantTableRestoreDefaults}
                     columns={this.getColumns()}
                     columnSelectors={this.getColumnSelectors()}
                     filters={this.getFilters()}
-                    sourceSelection={sourceSelection}
-                    columnSelection={columnSelection}
+                    sourceSelection={this.state.sourceSelection}
+                    columnSelection={this.state.columnSelection}
                     downloadButton={this.getDownloadButton}
                     lollipopButton={this.getLollipopButton}/>
             );
@@ -608,6 +622,9 @@ var VariantTableSupplier = function (Component) {
         getColumns: function () {
             return columns;
         },
+        expertVariantTableRestoreDefaults: function(callback) {
+            this.props.restoreDefaults(callback);
+        },
         render: function () {
             let expertColumns = _.object(_.map(this.getColumns(),
                 c => _.contains(getDefaultExpertColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
@@ -620,6 +637,7 @@ var VariantTableSupplier = function (Component) {
                     columns={this.getColumns()}
                     columnSelection={expertColumns}
                     sourceSelection={sourceSelection}
+                    expertVariantTableRestoreDefaults={this.expertVariantTableRestoreDefaults}
                     downloadButton={()=> null}
                     lollipopButton={()=> null}/>
             );

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -16,7 +16,7 @@ var DataTable = require('./DataTable');
 var _ = require('underscore');
 var {Col, Panel, Button, Input} = require('react-bootstrap');
 var ColumnCheckbox = require('./ColumnCheckbox');
-
+var {defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTableDefaults');
 
 require('react-data-components-bd2k/css/table-twbs.css');
 
@@ -30,49 +30,14 @@ function buildHeader(onClick, title) {
     );
 }
 
-//function renderClinVarLink(val) {
-//    return (
-//        <a title="View on ClinVar"
-//            onClick={ev => ev.stopPropagation()}
-//            href={"http://www.ncbi.nlm.nih.gov/clinvar/?term=" + val}>{val}</a>
-//    );
-//}
-
 function renderCell(val) {
     return <span>{val}</span>;
 }
 
 var filterColumns = [
     {name: 'Gene', prop: 'Gene_Symbol', values: ['BRCA1', 'BRCA2']},
-//    {name: 'Exon', values: ['Any', 1, 2, 3, 4, 5]}, // XXX needs refgene to get exon count
     {name: 'Pathogenicity', prop: 'Pathogenicity_expert', values: ['Pathogenic', 'Benign / Little Clinical Significance', 'Not Yet Classified']}
 ];
-
-// XXX duplicate this functionality on the server, perhaps
-// by having the client pass in order_by of Genomic_Coordinate
-// for hgvs columns.
-//var strPropCmpFn = prop => (a, b) => {
-//    var ap = a[prop],
-//        bp = b[prop];
-//    if (ap == null && bp == null || ap === bp) {
-//        return 0;
-//    }
-//    if (bp == null || bp < ap) {
-//        return 1;
-//    }
-//    return -1;
-//};
-//
-//var posCmpFn = strPropCmpFn('Genomic_Coordinate');
-//
-//function sortColumns(columns, {prop, order}, data) {
-//    var sortFn = _.findWhere(columns, {prop: prop}).sortFn || strPropCmpFn(prop),
-//        sorted = data.slice(0).sort(sortFn);
-//    if (order === 'descending') {
-//        sorted.reverse();
-//    }
-//    return sorted;
-//}
 
 const expertModeGroups = [
     {groupTitle: 'Variant Nomenclature', internalGroupName: 'Variant Nomenclature', innerCols: [
@@ -443,19 +408,6 @@ var subColumns = [
     },
 ];
 
-var defaultColumns = ['Gene_Symbol', 'HGVS_cDNA', 'HGVS_Protein', 'Protein_Change', 'BIC_Nomenclature', 'Pathogenicity_expert'];
-var defaultResearchColumns = ['Gene_Symbol', 'Genomic_Coordinate_hg38', 'HGVS_cDNA', 'HGVS_Protein', 'Pathogenicity_all', 'Allele_Frequency'];
-
-var allSources = {
-    "Variant_in_ENIGMA": 1,
-    "Variant_in_ClinVar": 1,
-    "Variant_in_1000_Genomes": 1,
-    "Variant_in_ExAC": 1,
-    "Variant_in_LOVD": 1,
-    "Variant_in_BIC": 1,
-    "Variant_in_ESP": 1,
-    "Variant_in_exLOVD": 1
-};
 /*eslint-enable camelcase */
 
 // Work-around to allow the user to select text in the table. The browser does not distinguish between
@@ -509,7 +461,7 @@ var ResearchVariantTableSupplier = function (Component) {
             let selectedColumns = JSON.parse(localStorage.getItem('columnSelection'));
             if (selectedColumns === null || selectedColumns === undefined) {
                 selectedColumns = _.object(_.map(this.getColumns(),
-                    c => _.contains(this.getDefaultColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
+                    c => _.contains(this.getDefaultResearchColumns(), c.prop) ? [c.prop, true] : [c.prop, false])
                 );
             }
             let selectedSources = JSON.parse(localStorage.getItem('selectedSources'));
@@ -583,7 +535,7 @@ var ResearchVariantTableSupplier = function (Component) {
         getColumns: function () {
             return researchModeColumns;
         },
-        getDefaultColumns: function () {
+        getDefaultResearchColumns: function () {
             return defaultResearchColumns;
         },
         render: function () {
@@ -612,7 +564,7 @@ var VariantTableSupplier = function (Component) {
             return columns;
         },
         getDefaultExpertColumns: function () {
-            return defaultColumns;
+            return defaultExpertColumns;
         },
         render: function () {
             let expertColumns = _.object(_.map(this.getColumns(),
@@ -641,8 +593,5 @@ module.exports = {
 	researchModeColumns: researchModeColumns,
 	columns: columns,
     researchModeGroups: researchModeGroups,
-    expertModeGroups: expertModeGroups,
-    defaultExpertColumns: defaultColumns,
-    defaultResearchColumns: defaultResearchColumns,
-    allSources: allSources
+    expertModeGroups: expertModeGroups
 };

--- a/website/js/VariantTableDefaults.js
+++ b/website/js/VariantTableDefaults.js
@@ -1,5 +1,7 @@
 /*global module: false, require: false, URL: false, Blob: false */
 'use strict';
+var _ = require('underscore');
+
 
 const defaultExpertColumns = ['Gene_Symbol', 'HGVS_cDNA', 'HGVS_Protein', 'Protein_Change', 'BIC_Nomenclature', 'Pathogenicity_expert'];
 const defaultResearchColumns = ['Gene_Symbol', 'Genomic_Coordinate_hg38', 'HGVS_cDNA', 'HGVS_Protein', 'Pathogenicity_all', 'Allele_Frequency'];
@@ -15,8 +17,23 @@ const allSources = {
     "Variant_in_exLOVD": 1
 };
 
+const getDefaultExpertColumns = function() {
+    // Returns clone of default expert columns.
+    return defaultExpertColumns.slice(0);
+}
+
+const getDefaultResearchColumns = function() {
+    // Returns clone of default research columns.
+    return defaultResearchColumns.slice(0);
+}
+
+const getAllSources = function() {
+    // Returns a clone of all sources object.
+    return _.clone(allSources);
+}
+
 module.exports = {
-    defaultExpertColumns: defaultExpertColumns,
-    defaultResearchColumns: defaultResearchColumns,
-    allSources: allSources
+    getDefaultExpertColumns: getDefaultExpertColumns,
+    getDefaultResearchColumns: getDefaultResearchColumns,
+    getAllSources: getAllSources
 };

--- a/website/js/VariantTableDefaults.js
+++ b/website/js/VariantTableDefaults.js
@@ -20,17 +20,17 @@ const allSources = {
 const getDefaultExpertColumns = function() {
     // Returns clone of default expert columns.
     return defaultExpertColumns.slice(0);
-}
+};
 
 const getDefaultResearchColumns = function() {
     // Returns clone of default research columns.
     return defaultResearchColumns.slice(0);
-}
+};
 
 const getAllSources = function() {
     // Returns a clone of all sources object.
     return _.clone(allSources);
-}
+};
 
 module.exports = {
     getDefaultExpertColumns: getDefaultExpertColumns,

--- a/website/js/VariantTableDefaults.js
+++ b/website/js/VariantTableDefaults.js
@@ -1,0 +1,22 @@
+/*global module: false, require: false, URL: false, Blob: false */
+'use strict';
+
+const defaultExpertColumns = ['Gene_Symbol', 'HGVS_cDNA', 'HGVS_Protein', 'Protein_Change', 'BIC_Nomenclature', 'Pathogenicity_expert'];
+const defaultResearchColumns = ['Gene_Symbol', 'Genomic_Coordinate_hg38', 'HGVS_cDNA', 'HGVS_Protein', 'Pathogenicity_all', 'Allele_Frequency'];
+
+const allSources = {
+    "Variant_in_ENIGMA": 1,
+    "Variant_in_ClinVar": 1,
+    "Variant_in_1000_Genomes": 1,
+    "Variant_in_ExAC": 1,
+    "Variant_in_LOVD": 1,
+    "Variant_in_BIC": 1,
+    "Variant_in_ESP": 1,
+    "Variant_in_exLOVD": 1
+};
+
+module.exports = {
+    defaultExpertColumns: defaultExpertColumns,
+    defaultResearchColumns: defaultResearchColumns,
+    allSources: allSources
+};

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -411,7 +411,6 @@ div#main {
 
 @media only screen and (min-width: 768px) {
     #data-table-container table {
-        table-layout: fixed;
         min-width: 612px;
     }
 

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -63,6 +63,28 @@ if (typeof console === "undefined") {
     };
 }
 
+function isEmptyVal(val) {
+    if ((typeof val === 'string' || val instanceof String) && val.trim() === '') {
+            return true;
+        } else if (val === null || val === undefined) {
+            return true;
+        } else {
+            return false;
+        }
+}
+
+function clean(obj) {
+    // Removes all empty values from object.
+    var propNames = Object.getOwnPropertyNames(obj);
+    for (var i = 0; i < propNames.length; i++) {
+        let propName = propNames[i];
+        let val = obj[propName];
+        if (isEmptyVal(val)) {
+            delete obj[propName];
+        }
+    }
+}
+
 var Footer = React.createClass({
     mixins: [PureRenderMixin],
     render: function() {
@@ -448,16 +470,6 @@ function isEmptyField(value) {
     return v === '' || v === '-' || v === 'None';
 }
 
-function isEmptyVal(val) {
-    if ((typeof val === 'string' || val instanceof String) && val.trim() === '') {
-            return true;
-        } else if (val === null || val === undefined) {
-            return true;
-        } else {
-            return false;
-        }
-}
-
 function isEmptyDiff(value) {
     return value === null || value.length < 1;
 }
@@ -504,18 +516,6 @@ function normalizedFieldDisplay(value) {
     }
 
     return value;
-}
-
-function clean(obj) {
-    // Removes all empty values from object.
-    var propNames = Object.getOwnPropertyNames(obj);
-    for (var i = 0; i < propNames.length; i++) {
-        let propName = propNames[i];
-        let val = obj[propName];
-        if (isEmptyVal(val)) {
-            delete obj[propName];
-        }
-    }
 }
 
 const IsoGrid = React.createClass({

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -42,7 +42,7 @@ var databaseKey = require('../databaseKey');
 var {Grid, Col, Row, Table, Button, Modal, Panel, Glyphicon} = require('react-bootstrap');
 
 /* FAISAL: added 'groups' collection that specifies how to map columns to higher-level groups */
-var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups} = require('./VariantTable');
+var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups, defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTable');
 var {Signup} = require('./Signup');
 var {Signin, ResetPassword} = require('./Signin');
 var {ConfirmEmail} = require('./ConfirmEmail');
@@ -209,40 +209,27 @@ function toNumber(v) {
 }
 
 function databaseParams(paramsIn) {
-    var {filter, filterValue, hide, hideSources, excludeSources, orderBy, order, search = '', changeTypes} = paramsIn;
+    var {orderBy, order, search = '', changeTypes} = paramsIn;
     var numParams = _.mapObject(_.pick(paramsIn, 'page', 'pageLength', 'release'), toNumber);
     var sortBy = {prop: orderBy, order};
-    var columnSelection = _.object(hide, _.map(hide, _.constant(false)));
-    var sourceSelection = {..._.object(hideSources, _.map(hideSources, _.constant(0))),
-                           ..._.object(excludeSources, _.map(excludeSources, _.constant(-1)))};
-    var filterValues = _.object(filter, filterValue);
-    return {changeTypes, search, sortBy, columnSelection, sourceSelection, filterValues, hide, ...numParams};
+    return {changeTypes, search, sortBy, ...numParams};
 }
 
 var transpose = a => _.zip.apply(_, a);
 
-function urlFromDatabase(state) {
+function urlFromDatabase(state, mode) {
     // Need to diff from defaults. The defaults are in DataTable.
     // We could keep the defaults here, or in a different module.
-    var {release, changeTypes, columnSelection, filterValues, sourceSelection,
-            search, page, pageLength, sortBy: {prop, order}} = state;
-    var hide = _.keys(_.pick(columnSelection, v => v === false));
-    var hideSources = _.keys(_.pick(sourceSelection, v => v === 0));
-    var excludeSources = _.keys(_.pick(sourceSelection, v => v === -1));
-    var [filter, filterValue] = transpose(_.pairs(_.pick(filterValues, v => v === true)));
+    var {release, changeTypes, search, page, pageLength,
+        sortBy: {prop, order}} = state;
     return _.pick({
         release,
         changeTypes,
         search: search === '' ? null : backend.trimSearchTerm(search),
-        filter,
-        filterValue,
         page: page === 0 ? null : page,
         pageLength: pageLength === 20 ? null : pageLength,
         orderBy: prop,
-        order,
-        hideSources: hideSources,
-        excludeSources: excludeSources,
-        hide: hide.length === 0 ? null : hide
+        order
     }, v => v != null);
 
 }
@@ -295,7 +282,10 @@ var Database = React.createClass({
                 d3TipDiv[0].style.opacity = '0';
                 d3TipDiv[0].style.pointerEvents = 'none';
             }
-            this.transitionTo('/variants', {}, urlFromDatabase(state));
+            if (this.state.showModal != true) {
+                // Don't change url if modal is open -- user is still deciding whether to change modes.
+                this.transitionTo('/variants', {}, urlFromDatabase(state, this.props.mode));
+            }
         }
     },
     toggleMode: function () {
@@ -397,8 +387,8 @@ const GroupHelpButton = React.createClass({
 // all data, otherwise go straight to all data. Finally, if key is not found, replace
 // _ with space in the key and return that.
 function getDisplayName(key) {
-    var researchMode = (localStorage.getItem("research-mode") === 'true');
-    var displayName;
+    const researchMode = (localStorage.getItem("research-mode") === 'true');
+    let displayName;
     if (!researchMode) {
         displayName = columns.find(e => e.prop === key);
         displayName = displayName && displayName.title;

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -52,8 +52,6 @@ var VariantSearch = require('./VariantSearch');
 var {Navigation, State, Route, RouteHandler,
     HistoryLocation, run, DefaultRoute, Link} = require('react-router');
 var {Releases, Release} = require('./Releases.js');
-var {defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTableDefaults');
-
 
 var navbarHeight = 70; // XXX This value MUST match the setting in custom.css
 
@@ -234,7 +232,7 @@ function urlFromDatabase(state) {
     var hide = _.keys(_.pick(columnSelection, v => v === false));
     var hideSources = _.keys(_.pick(sourceSelection, v => v === 0));
     var excludeSources = _.keys(_.pick(sourceSelection, v => v === -1));
-    var [filter, filterValue] = transpose(_.pairs(_.pick(filterValues, v => v === true)));
+    var [filter, filterValue] = transpose(_.pairs(filterValues, v => (v !== null && v !== undefined && v !== '')));
     return _.pick({
         release,
         changeTypes,

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -52,6 +52,8 @@ var VariantSearch = require('./VariantSearch');
 var {Navigation, State, Route, RouteHandler,
     HistoryLocation, run, DefaultRoute, Link} = require('react-router');
 var {Releases, Release} = require('./Releases.js');
+var {defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTableDefaults');
+
 
 var navbarHeight = 70; // XXX This value MUST match the setting in custom.css
 
@@ -222,8 +224,11 @@ function databaseParams(paramsIn) {
 var transpose = a => _.zip.apply(_, a);
 
 function urlFromDatabase(state) {
-    // Need to diff from defaults. The defaults are in DataTable.
-    // We could keep the defaults here, or in a different module.
+    // TODO: diff from defaults
+    // Use REACT tools in chrome to see flow of state/props. Make sure to build
+    // URL depending on mode -- i.e. if mode is default (expert), only hide non expert columns
+    // and deactivate all filters. If state filters/column selections are the same as defaults and
+    // if mode is research mode, check local storage to set filters/column selection.
     var {release, changeTypes, columnSelection, filterValues, sourceSelection,
          search, page, pageLength, sortBy: {prop, order}} = state;
     var hide = _.keys(_.pick(columnSelection, v => v === false));
@@ -327,7 +332,9 @@ var Database = React.createClass({
                     mode={this.props.mode}/>);
             message = this.renderMessage(content.pages.variantsResearch);
         } else {
+            // Always reset column and source selections to default in expert mode.
             params.columnSelection = {};
+            params.sourceSelection = {};
             table = (
 				<VariantTable
 					ref='table'

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -244,10 +244,7 @@ function databaseParams(paramsIn) {
 var transpose = a => _.zip.apply(_, a);
 
 function urlFromDatabase(state) {
-    // TODO: diff from defaults
-    // Use REACT tools in chrome to see flow of state/props. Make sure to build
-    // URL depending on mode -- i.e. if mode is default (expert), only hide non expert columns
-    // and deactivate all filters. If state filters/column selections are the same as defaults and
+    // If state filters/column selections are the same as defaults and
     // if mode is research mode, check local storage to set filters/column selection.
     let {release, changeTypes, columnSelection, filterValues, sourceSelection,
          search, page, pageLength, mode, sortBy: {prop, order}} = state;
@@ -261,7 +258,7 @@ function urlFromDatabase(state) {
         hideSources = '';
         excludeSources = '';
     }
-    // Remove empty values.
+    // Remove empty values from filterValues.
     clean(filterValues);
     let [filter, filterValue] = transpose(_.pairs(filterValues, v => (v !== null && v !== undefined && v !== '')));
     return _.pick({

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -244,8 +244,6 @@ function databaseParams(paramsIn) {
 var transpose = a => _.zip.apply(_, a);
 
 function urlFromDatabase(state) {
-    // If state filters/column selections are the same as defaults and
-    // if mode is research mode, check local storage to set filters/column selection.
     let {release, changeTypes, columnSelection, filterValues, sourceSelection,
          search, page, pageLength, mode, sortBy: {prop, order}} = state;
     if (mode !== "default") {

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -42,7 +42,7 @@ var databaseKey = require('../databaseKey');
 var {Grid, Col, Row, Table, Button, Modal, Panel, Glyphicon} = require('react-bootstrap');
 
 /* FAISAL: added 'groups' collection that specifies how to map columns to higher-level groups */
-var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups, defaultExpertColumns, defaultResearchColumns, allSources} = require('./VariantTable');
+var {VariantTable, ResearchVariantTable, researchModeColumns, columns, researchModeGroups, expertModeGroups} = require('./VariantTable');
 var {Signup} = require('./Signup');
 var {Signin, ResetPassword} = require('./Signin');
 var {ConfirmEmail} = require('./ConfirmEmail');
@@ -215,9 +215,7 @@ function databaseParams(paramsIn) {
     return {changeTypes, search, sortBy, ...numParams};
 }
 
-var transpose = a => _.zip.apply(_, a);
-
-function urlFromDatabase(state, mode) {
+function urlFromDatabase(state) {
     // Need to diff from defaults. The defaults are in DataTable.
     // We could keep the defaults here, or in a different module.
     var {release, changeTypes, search, page, pageLength,
@@ -282,9 +280,9 @@ var Database = React.createClass({
                 d3TipDiv[0].style.opacity = '0';
                 d3TipDiv[0].style.pointerEvents = 'none';
             }
-            if (this.state.showModal != true) {
+            if (this.state.showModal !== true) {
                 // Don't change url if modal is open -- user is still deciding whether to change modes.
-                this.transitionTo('/variants', {}, urlFromDatabase(state, this.props.mode));
+                this.transitionTo('/variants', {}, urlFromDatabase(state));
             }
         }
     },


### PR DESCRIPTION
This PR introduces local storage for managing column and filter selections and resolves several issues pertaining to table layout, local storage vs. query parameters vs. defaults, and bugs in expert mode. Changes are outlined below:

1. All filter selections and column selections are stored in local storage.
2. Several bugs regarding management of column selections and filter selections are now resolved such that query parameters correctly reflect applied selections.
3. Query params override local storage which overrides default settings. If neither query params nor local storage selections are available, default settings are used.
4. Fixes a bug so that expert mode always shows all columns and all sources.
5. Fixes a table layout issue when adding columns.
6. Fixes a bug when filtering for `Not Yet Reviewed` variants.