### PR TITLE
Increase height community pages map #509

### DIFF
--- a/website/js/Community.js
+++ b/website/js/Community.js
@@ -117,17 +117,17 @@ var Community = React.createClass({
             <Grid id="main-grid">
                 <Row id="message"> {message} </Row>
                 <Row>
-                    <Col sm={10} smOffset={1} md={8} mdOffset={2}>
+                    <Col md={10} mdOffset={1} sm={12}>
                         <span>The BRCA Exchange supports the exchange of information about BRCA1 and BRCA2 variants. Show your support by joining our mailing list and/or listing your name below as one of our supporters.</span>
                     </Col>
                 </Row>
                 <Row>
-                    <Col md={8} mdOffset={2} sm={10} smOffset={1}>
+                    <Col md={10} mdOffset={1} sm={12}>
                         <CommunityMap onFilterRole={this.onFilterRole} search={this.state.search}/>
                     </Col>
                 </Row>
                 <Row>
-                    <Col className="text-center" sm={12} smOffset={0} md={10} mdOffset={1}>
+                    <Col className="text-center" md={10} mdOffset={1} sm={12}>
                         <Link to="/mailinglist"><Button disabled={config.environment === 'beta' && 'disabled'}>Join the mailing list only</Button></Link>&nbsp;
                         <Link to="/signup"><Button disabled={config.environment === 'beta' && 'disabled'}>Join the mailing list and add me to the supporters</Button></Link>&nbsp;
                         <Link to="/signin"><Button disabled={config.environment === 'beta' && 'disabled'}>Edit your profile</Button></Link>
@@ -140,7 +140,7 @@ var Community = React.createClass({
 
                 </Row>
                 <Row>
-                    <Col className="btm-buffer" sm={10} smOffset={1} md={8} mdOffset={2}>
+                    <Col className="btm-buffer" md={10} mdOffset={1} sm={12}>
                         <Col sm={6} lg={5} style={{paddingRight: "0"}}>
                             <h4>Search for a community member:</h4>
                         </Col>
@@ -150,7 +150,7 @@ var Community = React.createClass({
                     </Col>
                 </Row>
                 <Row>
-                    <Col md={8} mdOffset={2} sm={10} smOffset={1}>
+                    <Col md={10} mdOffset={1} sm={12}>
                         <Table className="community" striped bordered>
                             <tbody>
                                 {rows}
@@ -159,7 +159,7 @@ var Community = React.createClass({
                     </Col>
                 </Row>
                 <Row>
-                    <Col sm={10} smOffset={1} md={8} mdOffset={2}>
+                    <Col md={10} mdOffset={1} sm={12}>
                         <span style={{verticalAlign: 'middle', display: 'inline-block'}}>
                         {(this.state.page * this.state.pageLength) + 1}-{Math.min((this.state.page + 1) * this.state.pageLength, this.state.count)} out of {this.state.count} members
                         </span>
@@ -194,8 +194,8 @@ var CommunityMap = React.createClass({
             var infowindow;
             var markers = this.markers = [];
             var map = this.map = new google.maps.Map(document.getElementById('communityMap'), {
-                center: {lat: 17, lng: -2.5},
-                zoom: 1,
+                center: {lat: 17, lng: 9.4},
+                zoom: 2,
                 scrollwheel: false,
                 mapTypeControl: false,
                 streetViewControl: false,
@@ -203,7 +203,10 @@ var CommunityMap = React.createClass({
                     "featureType": "administrative",
                     "elementType": "geometry.fill",
                     "stylers": [{ "visibility": "off" }]
-                }]
+                }],
+                zoomControlOptions: {
+                    position: google.maps.ControlPosition.LEFT_BOTTOM
+                }
             });
 
             map.addListener('click', function() {

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -572,7 +572,7 @@ th[role='columnheader'] .help, .help-target .help {
 
 #communityMap {
     width: 100%;
-    height: 300px;
+    height: 450px;
     margin: 20px auto 20px auto;
 }
 


### PR DESCRIPTION
I attempted to increase the map height to fix the duplicate continent/marker issue, but it appears to only increase the amount of map you can see; it doesn't affect the zoom. (I did end up increasing the map size to 450px because it does look better.)

I was able to find a zoom level (2 instead of 1) that just fits all the markers, although both the member in Hawaii and New Zealand are right against the edge of the map. I moved the zoom control from the bottom right to the bottom left (it's in an empty spot in the ocean now) so as not to occlude New Zealand.

In order accommodate all the markers horizontally at the new zoom level, I increased the number of columns for the page at the "medium" bootstrap size class from 8 to 10. I also took the liberty of changing the "small" class columns from 10 to 12, as the page looked a bit squashed at that size class.