### PR TITLE
remove max AF field from UI, save field in db but default to '-'

### DIFF
--- a/pipeline/data_merging/aggregate_across_columns.py
+++ b/pipeline/data_merging/aggregate_across_columns.py
@@ -199,74 +199,9 @@ def selectAlleleFrequency(row):
         return EMPTY
 
 
-def determineSubpopulationForMAF(field):
-    if "EA_" in field:
-        return "EA"
-    elif "AA_" in field:
-        return "AA"
-    elif "EUR_" in field:
-        return "EUR"
-    elif "AFR_" in field:
-        return "AFR"
-    elif "AMR_" in field:
-        return "AMR"
-    elif "EAS_" in field:
-        return "EAS"
-    elif "FIN_" in field:
-        return "FIN"
-    elif "NFE_" in field:
-        return "NFE"
-    elif "OTH_" in field:
-        return "OTH"
-    elif "SAS_" in field:
-        return "SAS"
-
-
-def determineSourceForMAF(field):
-    if "_ExAC" in field:
-        return "ExAC minus TCGA"
-    elif "_1000_Genomes" in field:
-        return "1000 Genomes"
-    elif "_ESP" in field:
-        return "ESP"
-
-
 def selectMaxAlleleFrequency(newRow):
-    maxFreq = 0
-    maxFreqString = EMPTY
-    allele_frequency_fields = [
-        "EA_Allele_Frequency_ESP",
-        "AA_Allele_Frequency_ESP",
-        "Allele_Frequency_ESP",
-        "EUR_Allele_frequency_1000_Genomes",
-        "AFR_Allele_frequency_1000_Genomes",
-        "AMR_Allele_frequency_1000_Genomes",
-        "EAS_Allele_frequency_1000_Genomes",
-        "SAS_Allele_frequency_1000_Genomes",
-        "Allele_frequency_AFR_ExAC",
-        "Allele_frequency_AMR_ExAC",
-        "Allele_frequency_EAS_ExAC",
-        "Allele_frequency_FIN_ExAC",
-        "Allele_frequency_NFE_ExAC",
-        "Allele_frequency_OTH_ExAC",
-        "Allele_frequency_SAS_ExAC"
-    ]
-    for field in allele_frequency_fields:
-        if newRow[field] != EMPTY and newRow[field] != None:
-            freqs = [float(i) for i in newRow[field].split(',')]
-            max_in_field = max(freqs)
-            if max_in_field > maxFreq:
-                source = determineSourceForMAF(field)
-                subpopulation = determineSubpopulationForMAF(field)
-                maxFreq = max_in_field
-                if "ExAC" in source:
-                    # Ensure exac values maintain 3 sigfigs
-                    maxFreqStringPrefix = str(utilities.round_sigfigs(float(max_in_field), 3))
-                    maxFreqStringSuffix = " (%s from %s)" % (subpopulation, source)
-                    maxFreqString = maxFreqStringPrefix + maxFreqStringSuffix
-                else:
-                    maxFreqString = "%f (%s from %s)" % (max_in_field, subpopulation, source)
-    return(maxFreqString)
+    # MaxAF was removed from the UI and is now automatically set to '-' as of 8/11/17.
+    return '-'
 
 
 def checkDiscordantStatus(row):

--- a/pipeline/data_merging/test_aggregate_across_columns.py
+++ b/pipeline/data_merging/test_aggregate_across_columns.py
@@ -1,6 +1,6 @@
 import pytest
 import unittest
-from aggregate_across_columns import selectMaxAlleleFrequency, determineSourceForMAF, determineSubpopulationForMAF
+from aggregate_across_columns import selectMaxAlleleFrequency
 
 
 class TestStringMethods(unittest.TestCase):
@@ -151,39 +151,19 @@ class TestStringMethods(unittest.TestCase):
 
         self.maxAlleleFrequencyField = "AFR_Allele_frequency_1000_Genomes"
 
-    def test_determine_source_for_max_allele_frequency(self):
-        source = determineSourceForMAF(self.maxAlleleFrequencyField)
-        self.assertEquals(source, "1000 Genomes")
-
-    def test_determine_subpopulation_for_max_allele_frequency(self):
-        subpopulation = determineSubpopulationForMAF(self.maxAlleleFrequencyField)
-        self.assertEquals(subpopulation, "AFR")
-
     def test_select_max_allele_frequency(self):
         maxFreqString = selectMaxAlleleFrequency(self.newRowAlleleFrequencies)
-        self.assertIn("0.1475", maxFreqString)
-        self.assertIn("AFR", maxFreqString)
-        self.assertIn("1000 Genomes", maxFreqString)
+        self.assertEquals(maxFreqString, '-')
 
         self.newRowAlleleFrequencies["Allele_frequency_SAS_ExAC"] = '0.305'
         maxFreqString = selectMaxAlleleFrequency(self.newRowAlleleFrequencies)
-        self.assertIn("0.305", maxFreqString)
-        # Ensure extra sig figs are not added
-        self.assertNotIn("0.3050", maxFreqString)
-        self.assertIn("SAS", maxFreqString)
-        self.assertIn("ExAC minus TCGA", maxFreqString)
+        self.assertEquals(maxFreqString, '-')
 
         for attr, value in self.newRowAlleleFrequencies.iteritems():
             self.newRowAlleleFrequencies[attr] = '-'
 
         maxFreqString = selectMaxAlleleFrequency(self.newRowAlleleFrequencies)
         self.assertEquals(maxFreqString, '-')
-
-        self.newRowAlleleFrequencies["Allele_frequency_SAS_ExAC"] = '9.03e-05'
-        maxFreqString = selectMaxAlleleFrequency(self.newRowAlleleFrequencies)
-        self.assertIn("9.03e-05", maxFreqString)
-        self.assertIn("SAS", maxFreqString)
-        self.assertIn("ExAC minus TCGA", maxFreqString)
 
 if __name__ == '__main__':
     pass

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -255,7 +255,7 @@ class transformer(object):
                              "Genomic_Coordinate_hg37", "Genomic_Coordinate_hg38", "HGVS_cDNA", "HGVS_Protein",
                              "Hg37_Start", "Hg37_End", "Hg36_Start", "Hg36_End", "BX_ID_ENIGMA", "BX_ID_ClinVar",
                              "BX_ID_BIC", "BX_ID_ExAC", "BX_ID_LOVD", "BX_ID_exLOVD", "BX_ID_1000_Genomes", "BX_ID_ESP",
-                             "Polyphen_Prediction", "Polyphen_Score", "Minor_allele_frequency_ESP"]
+                             "Polyphen_Prediction", "Polyphen_Score", "Minor_allele_frequency_ESP", "Max_Allele_Frequency"]
 
         # Header to group all logs the same variant
         variant_intro = "\n\n %s \n Old Source: %s \n New Source: %s \n\n" % (newRow["pyhgvs_Genomic_Coordinate_38"],

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -30,7 +30,8 @@ class TestStringMethods(unittest.TestCase):
                       'Polyphen_Score',
                       'Allele_count_AFR',
                       'Allele_Frequency',
-                      'Allele_frequency_FIN_ExAC'
+                      'Allele_frequency_FIN_ExAC',
+                      'Max_Allele_Frequency'
                      ]
         self.oldRow = {
                   'Pathogenicity_all': '',
@@ -49,7 +50,8 @@ class TestStringMethods(unittest.TestCase):
                   'Polyphen_Score': '0.992',
                   'Allele_count_AFR': '-',
                   'Allele_Frequency': '-',
-                  'Allele_frequency_FIN_ExAC': '-'
+                  'Allele_frequency_FIN_ExAC': '-',
+                  'Max_Allele_Frequency': '0.000132 (EAS from ExAC minus TCGA)'
                  }
 
         self.newRow = copy.deepcopy(self.oldRow)
@@ -514,6 +516,20 @@ class TestStringMethods(unittest.TestCase):
 
         self.newRow["Polyphen_Score"] = "0.283"
         self.newRow["Polyphen_Prediction"] = "probably_damaging"
+
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
+        diff = releaseDiff.diff_json
+        self.assertEqual(diff, {})
+        self.assertIsNone(change_type)
+
+    def test_ignores_max_allele_frequency_field(self):
+        releaseDiff.added_data = self.added_data
+        releaseDiff.diff = self.diff
+        releaseDiff.diff_json = self.diff_json
+        variant = 'chr17:g.43049067:C>T'
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+
+        self.newRow["Max_Allele_Frequency"] = "-"
 
         change_type = v1v2.compareRow(self.oldRow, self.newRow)
         diff = releaseDiff.diff_json

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -122,7 +122,6 @@ const researchModeGroups = [
     ]},
 
     {groupTitle: 'Allele Frequency Reference Sets', internalGroupName: 'Allele Frequency Reference Sets', innerCols: [
-        {title: 'Maximum Allele Frequency (1000 Genomes, ESP, ExAC minus TCGA)', prop: 'Max_Allele_Frequency', core: true},
         {title: 'Allele Frequency (1000 Genomes)', prop: 'Allele_frequency_1000_Genomes', core: true},
         {title: 'AFR Allele Frequency (1000 Genomes)', prop: 'AFR_Allele_frequency_1000_Genomes', core: true},
         {title: 'AMR Allele Frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes', core: true},
@@ -269,7 +268,6 @@ const researchModeColumns = [
     {title: 'AMR Allele Frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes'},
     {title: 'EAS Allele Frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes'},
     {title: 'EUR Allele Frequency (1000 Genomes)', prop: 'EUR_Allele_frequency_1000_Genomes'},
-    {title: 'Maximum Allele Frequency', prop: 'Max_Allele_Frequency'},
     {title: 'EA Allele Frequency (ESP)', prop: 'EA_Allele_Frequency_ESP'},
     {title: 'AA Allele Frequency (ESP)', prop: 'AA_Allele_Frequency_ESP'},
     {title: 'Allele Frequency (ESP)', prop: 'Allele_Frequency_ESP'},

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -268,6 +268,7 @@ const researchModeColumns = [
     {title: 'AMR Allele Frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes'},
     {title: 'EAS Allele Frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes'},
     {title: 'EUR Allele Frequency (1000 Genomes)', prop: 'EUR_Allele_frequency_1000_Genomes'},
+    {title: 'Maximum Allele Frequency', prop: 'Max_Allele_Frequency'},
     {title: 'EA Allele Frequency (ESP)', prop: 'EA_Allele_Frequency_ESP'},
     {title: 'AA Allele Frequency (ESP)', prop: 'AA_Allele_Frequency_ESP'},
     {title: 'Allele Frequency (ESP)', prop: 'Allele_Frequency_ESP'},

--- a/website/js/VariantTableDefaults.js
+++ b/website/js/VariantTableDefaults.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 
 
 const defaultExpertColumns = ['Gene_Symbol', 'HGVS_cDNA', 'HGVS_Protein', 'Protein_Change', 'BIC_Nomenclature', 'Pathogenicity_expert'];
-const defaultResearchColumns = ['Gene_Symbol', 'Genomic_Coordinate_hg38', 'HGVS_cDNA', 'HGVS_Protein', 'Pathogenicity_all', 'Max_Allele_Frequency'];
+const defaultResearchColumns = ['Gene_Symbol', 'Genomic_Coordinate_hg38', 'HGVS_cDNA', 'HGVS_Protein', 'Pathogenicity_all', 'Allele_Frequency'];
 
 const allSources = {
     "Variant_in_ENIGMA": 1,


### PR DESCRIPTION
1. Removes Maximum Allele Frequency data from the UI.
2. Ignores Maximum Allele Frequency in all future diffs, but retains field in existing diffs.
3. Replaces Maximum Allele Frequency with Allele Frequency as a default research column.
4. Sets all future Maximum Allele Frequency values to '-'.
