### PR TITLE
Closes #697, uses an internal name field on data_releases for display…

### DIFF
--- a/website/django/data/management/commands/addrelease.py
+++ b/website/django/data/management/commands/addrelease.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
 
         # Currently, the release name is just an ascending number starting at one for the first release.
         # To name the release we're adding, find the most recently added release and add 1 to its name.
-        release_name = str(int(DataRelease.objects.all().order_by('-date')[0].name) + 1)
+        release_name = int(DataRelease.objects.all().order_by('-name')[0].name) + 1
         release_id = DataRelease.objects.create(name=release_name, **notes).id
 
         reports_reader = csv.reader(reports_tsv, dialect="excel-tab")

--- a/website/django/data/management/commands/addrelease.py
+++ b/website/django/data/management/commands/addrelease.py
@@ -36,7 +36,10 @@ class Command(BaseCommand):
 
         notes['sources'] = ', '.join(sources)
 
-        release_id = DataRelease.objects.create(**notes).id
+        # Currently, the release name is just an ascending number starting at one for the first release.
+        # To name the release we're adding, find the most recently added release and add 1 to its name.
+        release_name = str(int(DataRelease.objects.all().order_by('-date')[0].name) + 1)
+        release_id = DataRelease.objects.create(name=release_name, **notes).id
 
         reports_reader = csv.reader(reports_tsv, dialect="excel-tab")
         reports_header = reports_reader.next()

--- a/website/django/data/migrations/0025_auto_20180110_2000.py
+++ b/website/django/data/migrations/0025_auto_20180110_2000.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Generated and customized by zfisch on 2018-01-10 16:04
+
+'''
+Adds a name field which starts at 1 and is set in ascending
+order based on the date field (when the release was generated).
+'''
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from data.utilities import set_release_name_defaults
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data', '0024_auto_20171005_1906'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='datarelease',
+            options={'ordering': ['date']},
+        ),
+        migrations.AddField(
+            model_name='datarelease',
+            name='name',
+            field=models.CharField(max_length=255, null=True)
+        ),
+        migrations.RunPython(set_release_name_defaults),
+
+        # make field non-nullable after defaults are set
+        migrations.AlterField(
+            model_name='datarelease',
+            name='name',
+            field=models.CharField(max_length=255),
+        ),
+    ]

--- a/website/django/data/migrations/0025_auto_20180116_1508.py
+++ b/website/django/data/migrations/0025_auto_20180116_1508.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='datarelease',
             name='name',
-            field=models.CharField(max_length=255, null=True)
+            field=models.PositiveIntegerField(null=True)
         ),
         migrations.RunPython(set_release_name_defaults),
 
@@ -34,6 +34,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='datarelease',
             name='name',
-            field=models.CharField(max_length=255),
+            field=models.PositiveIntegerField(),
         ),
     ]

--- a/website/django/data/models.py
+++ b/website/django/data/models.py
@@ -9,7 +9,7 @@ class DataRelease(models.Model):
     sources = models.TextField()
     md5sum = models.TextField()
     created = models.DateTimeField(auto_now_add=True, null=True)
-    name = models.PositiveIntegerField(null=True)
+    name = models.PositiveIntegerField()
 
     class Meta:
         db_table = "data_release"

--- a/website/django/data/models.py
+++ b/website/django/data/models.py
@@ -9,9 +9,11 @@ class DataRelease(models.Model):
     sources = models.TextField()
     md5sum = models.TextField()
     created = models.DateTimeField(auto_now_add=True, null=True)
+    name = models.CharField(max_length=255)
 
     class Meta:
         db_table = "data_release"
+        ordering = ['date']
 
 class ChangeType(models.Model):
     name = models.TextField()

--- a/website/django/data/models.py
+++ b/website/django/data/models.py
@@ -9,7 +9,7 @@ class DataRelease(models.Model):
     sources = models.TextField()
     md5sum = models.TextField()
     created = models.DateTimeField(auto_now_add=True, null=True)
-    name = models.CharField(max_length=255)
+    name = models.PositiveIntegerField(null=True)
 
     class Meta:
         db_table = "data_release"

--- a/website/django/data/test_search.py
+++ b/website/django/data/test_search.py
@@ -37,7 +37,7 @@ def create_variant_and_materialized_view(variant_data):
     try:
         data_release = DataRelease.objects.get(id=release_id)
     except DataRelease.DoesNotExist:
-        data_release = DataRelease.objects.create(date='2017-12-26', id=release_id)
+        data_release = DataRelease.objects.create(date='2017-12-26', id=release_id, name=1)
     with connection.cursor() as cursor:
         cursor.execute("REFRESH MATERIALIZED VIEW currentvariant")
     materialized_view = CurrentVariant.objects.get(Genomic_Coordinate_hg38=variant.Genomic_Coordinate_hg38)
@@ -218,6 +218,7 @@ class VariantTestCase(TestCase):
 
         response_data = json.loads(response.content)
         self.assertEqual(response_data["count"], 1)
+        self.assertEqual(response_data["releaseName"], 1)
 
         response_variant = response_data["data"][0]
 
@@ -242,6 +243,7 @@ class VariantTestCase(TestCase):
 
         response_data = json.loads(response.content)
         self.assertEqual(response_data["count"], 1)
+        self.assertIsNone(response_data["releaseName"])
 
         response_variant = response_data["data"][0]
 

--- a/website/django/data/utilities.py
+++ b/website/django/data/utilities.py
@@ -28,6 +28,6 @@ def set_release_name_defaults(apps, schema_editor):
     count = 1
     releases = DataRelease.objects.all().order_by('date')
     for release in releases:
-        release.name = str(count)
+        release.name = count
         release.save()
         count += 1

--- a/website/django/data/utilities.py
+++ b/website/django/data/utilities.py
@@ -1,4 +1,5 @@
 from django.db import connection
+from models import DataRelease
 
 
 def update_autocomplete_words():
@@ -21,3 +22,12 @@ def update_autocomplete_words():
 
                 CREATE INDEX words_idx ON words(word text_pattern_ops);
             """)
+
+
+def set_release_name_defaults(apps, schema_editor):
+    count = 1
+    releases = DataRelease.objects.all().order_by('date')
+    for release in releases:
+        release.name = str(count)
+        release.save()
+        count += 1

--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -128,12 +128,14 @@ def index(request):
     show_deleted = (request.GET.get('show_deleted', False) != False)
     deleted_count = 0
     synonyms_count = 0
+    release_name = None
 
     if release:
         query = Variant.objects.filter(Data_Release_id=int(release))
         if(change_types):
             change_types = map(lambda c: change_types_map[c], filter(lambda c: c in change_types_map, change_types))
             query = query.filter(Change_Type_id__in=change_types)
+        release_name = DataRelease.objects.get(id=int(release)).name
     else:
         query = CurrentVariant.objects
 
@@ -189,7 +191,7 @@ def index(request):
         count = query.count()
         query = select_page(query, page_size, page_num)
         # call list() now to evaluate the query
-        response = JsonResponse({'count': count, 'deletedCount': deleted_count, 'synonyms': synonyms_count, 'data': list(query.values(*column))})
+        response = JsonResponse({'count': count, 'deletedCount': deleted_count, 'synonyms': synonyms_count, 'releaseName': release_name, 'data': list(query.values(*column))})
         response['Access-Control-Allow-Origin'] = '*'
         return response
 

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -23,12 +23,13 @@ var merge = (...args) => _.extend({}, ...args);
 
 var Lollipop = require('./d3Lollipop');
 
-function setPages({data, count, deletedCount, synonyms}, pageLength) { //eslint-disable-line camelcase
+function setPages({data, count, deletedCount, synonyms, releaseName}, pageLength) { //eslint-disable-line camelcase
     return {
         data,
         count,
         deletedCount,
         synonyms,
+        releaseName,
         totalPages: Math.ceil(count / pageLength)
     };
 }
@@ -264,6 +265,7 @@ var DataTable = React.createClass({
                 changeString = "deleted";
             }
         }
+        let releaseName = this.state.releaseName;
         var deletedCount = this.state.deletedCount;
         var deletedVariantsNote = '';
         if (deletedCount) {
@@ -311,7 +313,7 @@ var DataTable = React.createClass({
                                 <label className='control-label label alert-danger matched-variant-count'>
                                     {count} matching {pluralize(count, 'variant')} {}
                                     {changeString ? changeString : ''} {}
-                                    {release ? 'in release ' + release : ''} {}
+                                    {release ? 'in release ' + releaseName : ''} {}
                                     {synonyms ? 'of which ' + synonyms + ' matched on synonyms' : ''}
                                 </label>
                                 {downloadButton(this.createDownload)}

--- a/website/js/Releases.js
+++ b/website/js/Releases.js
@@ -28,12 +28,12 @@ var Releases = React.createClass({
         var releases = this.state.releases;
         if (Array.isArray(releases)) {
             releases = releases.sort(function(a, b) {
-                return a.id - b.id;
+                return a.name - b.name;
             }).reverse();
         }
         var rows = _.map(releases, release => (
             <tr>
-                <td style={{ whiteSpace: 'nowrap' }}><Link to={`/release/${release.id}`}>Version {release.id}</Link></td>
+                <td style={{ whiteSpace: 'nowrap' }}><Link to={`/release/${release.id}`}>Version {release.name}</Link></td>
                 <td style={{ whiteSpace: 'nowrap' }}>{moment(release.date, "YYYY-MM-DDTHH:mm:ss").format("DD MMMM YYYY")}</td>
                 <td>{this.getSourceRepresentations(release.sources)}</td>
                 <td><Link to={`/variants?release=${release.id}&changeTypes[]=new`}>{release['variants_added']}</Link></td>


### PR DESCRIPTION
… purposes

Problem: Release names cannot be edited. Specifically, releases are currently named in the web portal by their id (see http://brcaexchange.org/releases), which is actually a value pulled directly from the data_release_seq_id table in postgres. Since the id is a primary key, it's extremely difficult to change. This is particularly problematic if a data deployment hits a snag -- the data_release_seq_id increments but no new data_release object is created in the database, so when a new one is created there's a missing number (e.g. the portal right now is missing Version 14).

Solution: Use a name field on data_release objects specifically for the release name. It is determined by the date the release data was generated in ascending order.

Potential outstanding issue: We use a release_id parameter in the query string to get and display specific releases in the web portal. The release_id still refers to the primary key, not the actual release name. This has the potential to confuse both users and developers.

@izcram This is most relevant to you with respect to data deployment.
@falquaddoomi This is most relevant to you with respect to user experience.

