### PR TITLE
don't do a cd in export_data_for_genome_browser.sh

### DIFF
--- a/pipeline/genomeBrowserTrack/export_data_for_genome_browser.sh
+++ b/pipeline/genomeBrowserTrack/export_data_for_genome_browser.sh
@@ -15,9 +15,6 @@ RELEASE_ARCHIVE=$1
 TMP_DIR="/tmp/export_genome_browser"
 TMP_OUT="${TMP_DIR}/brcaToBed_out"
 
-SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # path of this script plus some additional files
-cd ${SRC_DIR}
-
 mkdir -p ${TMP_OUT}
 
 tar zxf ${RELEASE_ARCHIVE} -C ${TMP_DIR}
@@ -26,19 +23,20 @@ HG19_BED=${TMP_OUT}/brcaExchange.hg19.bed
 HG38_BED=${TMP_OUT}/brcaExchange.hg38.bed
 AS=${TMP_OUT}/brcaExchange.as
 
-python brcaToBed.py -i ${TMP_DIR}/output/release/built_with_change_types.tsv -o19 ${HG19_BED} -o38 ${HG38_BED} -a ${AS}
+SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # path of this script plus some additional files
+python ${SRC_DIR}/brcaToBed.py -i ${TMP_DIR}/output/release/built_with_change_types.tsv -o19 ${HG19_BED} -o38 ${HG38_BED} -a ${AS}
 
 sort -k1,1 -k2,2 ${HG19_BED} -o ${HG19_BED}
 sort -k1,1 -k2,2 ${HG38_BED} -o ${HG38_BED}
 
-bedToBigBed -type=bed9+ -as=${AS} -tab ${HG19_BED} hg19.chrom.sizes hg19/brcaExchange.bb
-bedToBigBed -type=bed9+ -as=${AS} -tab ${HG38_BED} hg38.chrom.sizes hg38/brcaExchange.bb
+bedToBigBed -type=bed9+ -as=${AS} -tab ${HG19_BED} ${SRC_DIR}/hg19.chrom.sizes ${SRC_DIR}/hg19/brcaExchange.bb
+bedToBigBed -type=bed9+ -as=${AS} -tab ${HG38_BED} ${SRC_DIR}/hg38.chrom.sizes ${SRC_DIR}/hg38/brcaExchange.bb
 
 # preparing trackhubs directory, which then gets pushed to the remote machine
 TRACKHUBS=${TMP_DIR}/trackhubs
 [ ! -e ${TRACKHUBS} ] && mkdir ${TRACKHUBS}
 
-cp -R hub.txt genomes.txt hg19 hg38 ${TRACKHUBS}
+cp -R ${SRC_DIR}/hub.txt ${SRC_DIR}/genomes.txt ${SRC_DIR}/hg19 ${SRC_DIR}/hg38 ${TRACKHUBS}
 
 scp -rq ${TRACKHUBS}/. brca@${HOST}:/var/www/html/production/trackhubs/
 


### PR DESCRIPTION
s.t. relative paths work for the release archive (#696)