### PR TITLE
Fix narrow viewport overflow #722

### DIFF
--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -359,17 +359,19 @@ var DataTable = React.createClass({
                     </Col>
                 </Row>
                 <Row>
-                    <Col id="data-table-container" className="table-responsive" sm={12}>
-                        <FastTable
-                            className={cx(className, "table table-hover table-bordered table-grayheader")}
-                            dataArray={data}
-                            columns={renderColumns}
-                            keys={this.props.keys}
-                            buildRowOptions={this.props.buildRowOptions}
-                            onRowClick={this.props.onRowClick}
-                            buildHeader={this.props.buildHeader}
-                            sortBy={this.state.sortBy}
-                            onSort={this.onSort} />
+                    <Col id="data-table-container" sm={12}>
+                        <div className="table-responsive">
+                            <FastTable
+                                className={cx(className, "table table-hover table-bordered table-grayheader")}
+                                dataArray={data}
+                                columns={renderColumns}
+                                keys={this.props.keys}
+                                buildRowOptions={this.props.buildRowOptions}
+                                onRowClick={this.props.onRowClick}
+                                buildHeader={this.props.buildHeader}
+                                sortBy={this.state.sortBy}
+                                onSort={this.onSort} />
+                        </div>
                     </Col>
                 </Row>
                 <Row>

--- a/website/js/DataTable.js
+++ b/website/js/DataTable.js
@@ -310,11 +310,16 @@ var DataTable = React.createClass({
                     <Col sm={8} lg={10}>
                         <div className='form-inline'>
                             <div className='form-group'>
-                                <label className='control-label label alert-danger matched-variant-count'>
-                                    {count} matching {pluralize(count, 'variant')} {}
-                                    {changeString ? changeString : ''} {}
-                                    {release ? 'in release ' + releaseName : ''} {}
-                                    {synonyms ? 'of which ' + synonyms + ' matched on synonyms' : ''}
+                                <label className='alert-danger matched-variant-count'>
+                                {
+                                    `${count} matching ${pluralize(count, 'variant')}
+                                    ${changeString ? changeString : ''}
+                                    ${release ? 'in release ' + releaseName : ''}
+                                    ${synonyms ? 'of which ' + synonyms + ' matched on synonyms' : ''}`
+                                    .replace(/[\n\t]/g, '')
+                                    // using string interpolation prevents react from creating one span tag per string.
+                                    // the replace() removes the extra whitespace used to make the code legible
+                                }
                                 </label>
                                 {downloadButton(this.createDownload)}
                             </div>

--- a/website/js/Releases.js
+++ b/website/js/Releases.js
@@ -48,20 +48,22 @@ var Releases = React.createClass({
                     <Col smOffset={1} sm={10}>
                         <h1>Release Notes</h1>
                         <br />
-                        <table className="table table-bordered table-grayheader nopointer">
-                            <thead>
-                                <th>Notes</th>
-                                <th>Date</th>
-                                <th>Data Sources</th>
-                                <th>New Variants</th>
-                                <th>New Classifications</th>
-                                <th>Changed/Updated Variants</th>
-                                <th>Removed Variants</th>
-                            </thead>
-                            <tbody>
-                                {rows}
-                            </tbody>
-                        </table>
+                        <div className="table-responsive table-responsive-outset">
+                            <table className="table table-inset-bordered table-grayheader nopointer">
+                                <thead>
+                                    <th>Notes</th>
+                                    <th>Date</th>
+                                    <th>Data Sources</th>
+                                    <th>New Variants</th>
+                                    <th>New Classifications</th>
+                                    <th>Changed/Updated Variants</th>
+                                    <th>Removed Variants</th>
+                                </thead>
+                                <tbody>
+                                    {rows}
+                                </tbody>
+                            </table>
+                        </div>
                     </Col>
                 </Row>
             </Grid>);

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -265,11 +265,8 @@ input:focus {
 }
 
 .matched-variant-count {
-    /* from bootstrap label */
     border-radius: .25em;
-    
     font-size: 1.2em;
-    /* line-height: 34px; */
 }
 
 /* used for the message on the search page */

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -265,8 +265,11 @@ input:focus {
 }
 
 .matched-variant-count {
+    /* from bootstrap label */
+    border-radius: .25em;
+    
     font-size: 1.2em;
-    line-height: 34px;
+    /* line-height: 34px; */
 }
 
 /* used for the message on the search page */
@@ -558,7 +561,9 @@ html {
 
 #download .alert-danger {
     padding: 7px;
-    vertical-align: bottom;
+    /* causes the download button to properly vertically align with the label */
+    margin-top: 5px;
+    vertical-align: middle;
 }
 
 .form-group label {

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -49,6 +49,38 @@ offending file, for future reference: website/node_modules/react-data-components
     cursor: auto;
 }
 
+/* table-inset-bordered draws borders on a table like table-bordered, but skips the outer border */
+.table-inset-bordered > thead > tr > th,
+.table-inset-bordered > tbody > tr > th,
+.table-inset-bordered > tfoot > tr > th,
+.table-inset-bordered > thead > tr > td,
+.table-inset-bordered > tbody > tr > td,
+.table-inset-bordered > tfoot > tr > td {
+    border: 1px solid #ddd;
+}
+
+/* double-thick bottom header border */
+.table-inset-bordered > thead > tr > th, .table-inset-bordered > thead > tr > td {
+    border-bottom-width: 2px;
+}
+
+/* strip borders on outer edges of the table */
+.table-inset-bordered > thead > tr > th:first-child { border-left: none; }
+.table-inset-bordered > thead > tr:first-child > th { border-top: none; }
+.table-inset-bordered > thead > tr > th:last-child { border-right: none; }
+.table-inset-bordered > tbody > tr > td:first-child { border-left: none; }
+.table-inset-bordered > tbody > tr > td:last-child { border-right: none; }
+.table-inset-bordered > tbody > tr:last-child > td { border-bottom: none; }
+
+/* if it's within a responsive 'outset' (i.e. the thing drawing the border), collapse the inner margin and add a new one */
+.table-responsive-outset .table-inset-bordered {
+    margin-bottom: 0;
+}
+.table-responsive-outset {
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+}
+
 /**************************************************************/
 /**********         NavBar                *********************/
 /**************************************************************/

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -943,7 +943,7 @@ var VariantDetail = React.createClass({
                     <Col md={12} className="variant-history-col">
                         <h3>{variant["HGVS_cDNA"]}</h3>
                         <h4>Previous Versions of this Variant:</h4>
-                        <Table className='variant-history nopointer' bordered>
+                        <Table className='variant-history nopointer' responsive bordered>
                             <thead>
                                 <tr className='active'>
                                     <th>Release Date</th>


### PR DESCRIPTION
Addresses #722. Allows the widths of certain elements that were previously stretching the page past the viewport on narrow displays to collapse. Specifically, the following pages' elements have been modified:

- **Variant Search:**
  - the label indicating the number of results, duplicates, etc. has had the "label" class removed, which was disallowing it from wrapping. Relevant rules have been copied into its own class, "matched-variant-count".
  - the results table previously had a few pixels of space between the table's border and its content. Moving the "table-responsive" class from its parent Col element to a new wrapping div resolved the left padding, but oddly not the right padding, although it's less noticeably since the user has to scroll to see it.
- **Variant Details:**
  - the version history table now has the "table-responsive" class, which causes it to scroll internally (rather than stretch the page) if its content is wider than the page can accommodate. I'm very mildly concerned that users might not be able to find the "changes" column if they don't realize the version history table scrolls, although I think it's better than the menu button being obscured.