### PR TITLE
script and some instructions to reproduce the merging stage of the pi…

### DIFF
--- a/pipeline/docker/reproducibility/README.md
+++ b/pipeline/docker/reproducibility/README.md
@@ -1,0 +1,12 @@
+## BRCA Exchange Reproducibility
+
+Reproducing the results of the entire pipeline is difficult since raw data at the sources may have evolved meanwhile and also because the access to raw data used for some sources is restricted. For the latter case, you'd have to request access to those.
+
+The pipeline consists of 2 stages where the first one is to normalize the data from each source and the second to merge all variants and do further processing. Since the output of the first stage is included in a release archive, the second stage can be relatively easily reproduced. Note, however, that also for this part some discrepancies may arise due to the fact, that the second stage relies on external webservices.
+
+## Reproducing Merging Stage
+  
+1. Make sure you have docker installed on your system 
+2. Copy, edit accordingly the variables annotated with `PLEASE EDIT` and run [this script](https://github.com/BRCAChallenge/brca-exchange/blob/master/pipeline/docker/reproducibility/reproduce_merging.sh): 
+   It will download necessary release archives, some auxiliary data and run the docker image of the merging part.
+3. If everything went well, the script will output a path were the newly generated release archive can be found.

--- a/pipeline/docker/reproducibility/README.md
+++ b/pipeline/docker/reproducibility/README.md
@@ -7,6 +7,6 @@ The pipeline consists of 2 stages where the first one is to normalize the data f
 ## Reproducing Merging Stage
   
 1. Make sure you have docker installed on your system 
-2. Copy, edit accordingly the variables annotated with `PLEASE EDIT` and run [this script](https://github.com/BRCAChallenge/brca-exchange/blob/master/pipeline/docker/reproducibility/reproduce_merging.sh): 
+2. Copy and run [this script](https://github.com/BRCAChallenge/brca-exchange/blob/master/pipeline/docker/reproducibility/reproduce_merging.sh): 
    It will download necessary release archives, some auxiliary data and run the docker image of the merging part.
 3. If everything went well, the script will output a path were the newly generated release archive can be found.

--- a/pipeline/docker/reproducibility/reproduce_merging.sh
+++ b/pipeline/docker/reproducibility/reproduce_merging.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+###############################################################################
+# Script to partially reproduce the result from the BRCA Exchange pipeline.
+#
+# Please edit the PLEASE EDIT parts accordingly
+###############################################################################
+
+# Base directory
+# PLEASE EDIT
+BASE=~/please_edit
+
+# date of the release to reproduce
+# you can lookup release dates here: http://brcaexchange.org/releases
+# PLEASE EDIT
+RELEASE_DATE="2018-02-17" 
+
+# previous release date of the release to reproduce
+# PLEASE EDIT
+PREVIOUS_RELEASE_DATE="2018-01-16" 
+
+IMAGE="brcachallenge/brca-exchange-pipeline:data_release_${RELEASE_DATE}"
+
+###############################################################################
+
+SED_DATE_CONVERSION_CMD="s/20([0-9]{2})-([0-9]{2})-([0-9]{2})/\2-\3-\1/g"
+
+RELEASE_DATE_US=$(echo ${RELEASE_DATE} | sed -E ${SED_DATE_CONVERSION_CMD})
+RELEASE_ARCHIVE=${BASE}/release-${RELEASE_DATE_US}.tar.gz
+wget "http://brcaexchange.org/backend/downloads/releases/release-${RELEASE_DATE_US}/release-${RELEASE_DATE_US}.tar.gz" -O ${RELEASE_ARCHIVE}
+
+PREVIOUS_RELEASE_DATE_US=$(echo ${PREVIOUS_RELEASE_DATE} | sed -E ${SED_DATE_CONVERSION_CMD})
+PREVIOUS_RELEASE_ARCHIVE=${BASE}/release-${PREVIOUS_RELEASE_DATE_US}.tar.gz
+wget "http://brcaexchange.org/backend/downloads/releases/release-${PREVIOUS_RELEASE_DATE_US}/release-${PREVIOUS_RELEASE_DATE_US}.tar.gz" -O ${PREVIOUS_RELEASE_ARCHIVE}
+
+# Download auxiliary resources
+RESOURCE_DIR=${BASE}/resources
+if [ ! -d ${RESOURCE_DIR} ]
+then
+    mkdir -p ${RESOURCE_DIR}
+
+    echo "$(date) Downloading resources files..."
+    docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) \
+           -v ${RESOURCE_DIR}:/files/resources \
+           ${IMAGE} \
+           /opt/brca-exchange/pipeline/download_resources_files.sh /files/resources
+fi
+
+# Creating dummy release notes file
+RELEASE_NOTES=${BASE}/some_release_notes.txt
+touch ${RELEASE_NOTES}
+
+# Creating dummy credentials file
+CREDENTIALS_FILE=${BASE}/dummy_credentials_file.cfg
+touch ${CREDENTIALS_FILE}
+
+OUTPUT_DIR=${BASE}/brca_out
+mkdir -p ${OUTPUT_DIR}
+
+# extracting required files from release tar
+# excluding the output/release directory, because this is what we want to reproduce
+tar zxf ${RELEASE_ARCHIVE} -C ${OUTPUT_DIR} --exclude 'output/release' 'output/*.vcf*' 'output/*.tsv'
+
+echo "$(date) Running BRCA Exchange pipeline (merging part)"
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) \
+       -e "DATA_DATE=${RELEASE_DATE}" \
+       -v ${RESOURCE_DIR}:/files/resources \
+       -v ${OUTPUT_DIR}:/files/data \
+       -v ${PREVIOUS_RELEASE_ARCHIVE}:/files/previous_release.tar.gz \
+       -v ${RELEASE_NOTES}:/files/release_notes.txt \
+       ${IMAGE}
+
+echo "If everything went well, find the reproduced archive in ${OUTPUT_DIR}/release-${RELEASE_DATE_US}.tar.gz"

--- a/pipeline/docker/reproducibility/reproduce_merging.sh
+++ b/pipeline/docker/reproducibility/reproduce_merging.sh
@@ -7,10 +7,16 @@
 if [[ $# -ne 3 ]]; then
     echo "Expecting 3 arguments, got $#"
     echo "Usage $0: base_dir release_date previous_release_date"
+    echo ""
     echo "where:"
     echo "    base_dir: path to base directory for the analysis"
     echo "    release_date: date of the release to reproduce, e.g. '2018-02-17'"
     echo "    previous_release_date: date of the release prior to release to be reproduced, e.g. '2018-01-16'"
+    echo ""
+    echo "Example:"
+    echo ""
+    echo "./reproduce_merging.sh /tmp/reproductions/ 2018-02-17 2018-01-16"
+    echo ""
     echo "Note: you can lookup release dates here: http://brcaexchange.org/releases"
     exit 2
 fi
@@ -79,7 +85,8 @@ mkdir -p ${OUTPUT_DIR}
 
 # extracting required files from release tar
 # excluding the output/release directory, because this is what we want to reproduce
-tar zxf ${RELEASE_ARCHIVE} -C ${OUTPUT_DIR} --exclude 'output/release' 'output/*.vcf*' 'output/*.tsv'
+[[ "$OSTYPE" == "linux-gnu" ]] && WILDCARDS_OPT='--wildcards' # hacking around differing support across platforms of the --wildcards tar option
+tar zxf ${RELEASE_ARCHIVE} ${WILDCARDS_OPT} -C ${OUTPUT_DIR} --exclude 'output/release' 'output/*.vcf*' 'output/*.tsv'
 
 echo "$(date) Running BRCA Exchange pipeline (merging part)"
 docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) \

--- a/pipeline/docker/reproducibility/reproduce_merging.sh
+++ b/pipeline/docker/reproducibility/reproduce_merging.sh
@@ -2,26 +2,32 @@
 
 ###############################################################################
 # Script to partially reproduce the result from the BRCA Exchange pipeline.
-#
-# Please edit the PLEASE EDIT parts accordingly
 ###############################################################################
 
-# Base directory
-# PLEASE EDIT
-BASE=~/please_edit
+if [[ $# -ne 3 ]]; then
+    echo "Expecting 3 arguments, got $#"
+    echo "Usage $0: base_dir release_date previous_release_date"
+    echo "where:"
+    echo "    base_dir: path to base directory for the analysis"
+    echo "    release_date: date of the release to reproduce, e.g. '2018-02-17'"
+    echo "    previous_release_date: date of the release prior to release to be reproduced, e.g. '2018-01-16'"
+    echo "Note: you can lookup release dates here: http://brcaexchange.org/releases"
+    exit 2
+fi
 
-# date of the release to reproduce
-# you can lookup release dates here: http://brcaexchange.org/releases
-# PLEASE EDIT
-RELEASE_DATE="2018-02-17" 
-
-# previous release date of the release to reproduce
-# PLEASE EDIT
-PREVIOUS_RELEASE_DATE="2018-01-16" 
+BASE=$1
+RELEASE_DATE=$2
+PREVIOUS_RELEASE_DATE=$3
 
 IMAGE="brcachallenge/brca-exchange-pipeline:data_release_${RELEASE_DATE}"
 
 ###############################################################################
+
+# convert to absolute path (required by docker daemon)
+if [[ ! "${BASE}" =~ ^/ ]]
+then
+    BASE="$(pwd)/${BASE}"
+fi
 
 SED_DATE_CONVERSION_CMD="s/20([0-9]{2})-([0-9]{2})-([0-9]{2})/\2-\3-\1/g"
 

--- a/pipeline/docker/reproducibility/reproduce_merging.sh
+++ b/pipeline/docker/reproducibility/reproduce_merging.sh
@@ -31,13 +31,27 @@ fi
 
 SED_DATE_CONVERSION_CMD="s/20([0-9]{2})-([0-9]{2})-([0-9]{2})/\2-\3-\1/g"
 
+function download_release_archive()
+{
+    DATE_US=$1
+    TARGET=$2
+
+    URL="http://brcaexchange.org/backend/downloads/releases/release-${DATE_US}/release-${DATE_US}.tar.gz" 
+    wget "${URL}" -O ${TARGET}
+
+    if [ "$?" -ne "0" ]; then
+        echo "Failed to download archive $URL. Please check http://brcaexchange.org/releases for the available release dates"
+        exit 1
+    fi
+}
+
 RELEASE_DATE_US=$(echo ${RELEASE_DATE} | sed -E ${SED_DATE_CONVERSION_CMD})
 RELEASE_ARCHIVE=${BASE}/release-${RELEASE_DATE_US}.tar.gz
-wget "http://brcaexchange.org/backend/downloads/releases/release-${RELEASE_DATE_US}/release-${RELEASE_DATE_US}.tar.gz" -O ${RELEASE_ARCHIVE}
+download_release_archive ${RELEASE_DATE_US} ${RELEASE_ARCHIVE}
 
 PREVIOUS_RELEASE_DATE_US=$(echo ${PREVIOUS_RELEASE_DATE} | sed -E ${SED_DATE_CONVERSION_CMD})
 PREVIOUS_RELEASE_ARCHIVE=${BASE}/release-${PREVIOUS_RELEASE_DATE_US}.tar.gz
-wget "http://brcaexchange.org/backend/downloads/releases/release-${PREVIOUS_RELEASE_DATE_US}/release-${PREVIOUS_RELEASE_DATE_US}.tar.gz" -O ${PREVIOUS_RELEASE_ARCHIVE}
+download_release_archive ${PREVIOUS_RELEASE_DATE_US} ${PREVIOUS_RELEASE_ARCHIVE}
 
 # Download auxiliary resources
 RESOURCE_DIR=${BASE}/resources


### PR DESCRIPTION
…peline using the original docker images

The docker images required to reproduce the data are now pushed monthly to dockerhub during the release process.
See also https://hub.docker.com/r/brcachallenge/brca-exchange-pipeline
