### PR TITLE
Circle2.0 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,18 @@ jobs:
            name: deploy to dev if on master branch
            command: |
              if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                 echo "Deploying master branch on dev machine"
                  ~/project/deployment/deploy-dev
+             else
+                 echo "on branch ${CIRCLE_BRANCH}. No deployment on dev machine"
              fi
+
        - deploy:
            name: deploy to beta if appropriate tag was pushed
            command: |
              if [[ "${CIRCLE_TAG}" =~ v[0-9]+(\.[0-9]+)* ]]; then
+                echo "Deploying tag ${CIRCLE_TAG} on beta machine"
                 HOST=brcaexchange.cloudapp.net ~/project/deployment/deploy-dev
+             else
+                echo "Tag is ${CIRCLE_TAG}. No deployment on beta"
              fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,41 +49,18 @@ jobs:
              cd ~/project/pipeline && pytest --ignore=website/ --junitxml=~/test_reports/pytest-results.xml
        - store_test_results:
            path: ~/test_reports
-   deploy-dev:
-      docker:
-        - image: circleci/node:6.13
-      steps:
-        - checkout
-        - run:
-            name: deploying to dev machine
-            command: ~/project/deployment/deploy-dev
-   deploy-beta:
-      docker:
-        - image: circleci/node:6.13
-      steps:
-        - checkout
-        - run:
-            name: deploying to beta machine
-            command: HOST=brcaexchange.cloudapp.net ~/project/deployment/deploy-dev
-workflows:
-  version: 2
-  build-n-deploy:
-    jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
-      - deploy-dev:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-      - deploy-beta:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-            branches:
-              ignore: /.*/
+       - run:
+           name: Set up environment for deployment
+           command: sudo apt-get install rsync
+       - deploy:
+           name: deploy to dev if on master branch
+           command: |
+             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                 ~/project/deployment/deploy-dev
+             fi
+       - deploy:
+           name: deploy to beta if appropriate tag was pushed
+           command: |
+             if [[ "${CIRCLE_TAG}" =~ v[0-9]+(\.[0-9]+)* ]]; then
+                HOST=brcaexchange.cloudapp.net ~/project/deployment/deploy-dev
+             fi


### PR DESCRIPTION
Issue was, that in each workflow job it started from a fresh image, so in the deployment steps would need to redo `npm install`. There might be away around this by reusing the container from the build step.
However, going away from workflows as it seems a bit an overkill and currently cannot be tested locally (see note in https://circleci.com/docs/2.0/local-cli/#overview)