### PR TITLE
Mupit aa update

### DIFF
--- a/pipeline/data_merging/getMupitStructure.py
+++ b/pipeline/data_merging/getMupitStructure.py
@@ -33,7 +33,7 @@ def isPointSubstitution(ref, alt):
 def hasRelevantProteinChange(hgvsProtein):
     # NOTE: if this requires updating, also update has_relevant_protein_change in django/data/utilities.py
     # ignore variants with no amino acid change or variants with an unknown amino acid change
-    if "?" in hgvsProtein or "=" in hgvsProtein:
+    if "?" in hgvsProtein or "=" in hgvsProtein or "*" in hgvsProtein:
         return False
 
     # remove all numbers and brackets from protein

--- a/pipeline/data_merging/getMupitStructure.py
+++ b/pipeline/data_merging/getMupitStructure.py
@@ -30,6 +30,23 @@ def isPointSubstitution(ref, alt):
     return False
 
 
+def hasRelevantProteinChange(hgvsProtein):
+    # NOTE: if this requires updating, also update has_relevant_protein_change in django/data/utilities.py
+    # ignore variants with no amino acid change or variants with an unknown amino acid change
+    if "?" in hgvsProtein or "=" in hgvsProtein:
+        return False
+
+    # remove all numbers and brackets from protein
+    strippedHgvs = ''.join([i for i in hgvsProtein if not (i.isdigit() or i in ['(', ')'])])
+    hgvsLastThreeChars = strippedHgvs[-3:]
+
+    # ignore variants with an introduced stop codon
+    if hgvsLastThreeChars == "Ter":
+        return False
+
+    return True
+
+
 def main(args):
     options = parse_args()
     inputFile = options.input
@@ -50,19 +67,21 @@ def main(args):
     posIndex = input_header_row.index("Pos")
     refIndex = input_header_row.index("Ref")
     altIndex = input_header_row.index("Alt")
+    proteinIndex = input_header_row.index("pyhgvs_Protein")
 
     for variant in input_file:
         chrom = "chr" + variant[chromIndex]
         pos = int(variant[posIndex])
         ref = variant[refIndex]
         alt = variant[altIndex]
+        hgvsProtein = variant[proteinIndex]
 
         # Add empty data for each new column to prepare for data insertion by index
         for i in range(len(new_columns_to_append)):
             variant.append('-')
 
         # only check mupit structure for point substitutions in relevant positions
-        if isPointSubstitution(ref, alt) and isRelevantPosition(pos):
+        if isPointSubstitution(ref, alt) and isRelevantPosition(pos) and hasRelevantProteinChange(hgvsProtein):
 
             mupit_structure = get_brca_struct(chrom, pos)
 

--- a/website/django/data/utilities.py
+++ b/website/django/data/utilities.py
@@ -86,7 +86,7 @@ def is_relevant_position(pos):
 def has_relevant_protein_change(hgvs_protein):
     # NOTE: if this requires updating, also update hasRelevantProteinChange in pipeline/data_merging/getMupitStructure.py
     # ignore variants with no amino acid change or variants with an unknown amino acid change
-    if "?" in hgvs_protein or "=" in hgvs_protein:
+    if "?" in hgvs_protein or "=" in hgvs_protein or "*" in hgvs_protein:
         return False
 
     # remove all numbers and brackets from protein

--- a/website/django/data/utilities.py
+++ b/website/django/data/utilities.py
@@ -69,7 +69,7 @@ def send_mupit_request(query_url, params):
     sys.exit(1)
 
 
-def isPointSubstitution(ref, alt):
+def is_point_substitution(ref, alt):
     bases = ['a', 'c', 't', 'g']
     ref = ref.lower()
     alt = alt.lower()
@@ -83,6 +83,23 @@ def is_relevant_position(pos):
     return (pos >= 32356427 and pos <= 32396972) or (pos >= 43045692 and pos <= 43125184)
 
 
+def has_relevant_protein_change(hgvs_protein):
+    # NOTE: if this requires updating, also update hasRelevantProteinChange in pipeline/data_merging/getMupitStructure.py
+    # ignore variants with no amino acid change or variants with an unknown amino acid change
+    if "?" in hgvs_protein or "=" in hgvs_protein:
+        return False
+
+    # remove all numbers and brackets from protein
+    stripped_hgvs = ''.join([i for i in hgvs_protein if not (i.isdigit() or i in ['(', ')'])])
+    hgvs_last_three_chars = stripped_hgvs[-3:]
+
+    # ignore variants with an introduced stop codon
+    if hgvs_last_three_chars == "Ter":
+        return False
+
+    return True
+
+
 def update_mupit_structure_for_existing_variants():
     mupit_structures = {ms['name']: ms['id'] for ms in MupitStructure.objects.values()}
     cvs = CurrentVariant.objects.all()
@@ -92,7 +109,8 @@ def update_mupit_structure_for_existing_variants():
         pos = int(getattr(variant, 'Pos'))
         ref = getattr(variant, 'Ref')
         alt = getattr(variant, 'Alt')
-        if isPointSubstitution(ref, alt) and is_relevant_position(pos):
+        hgvs_protein = getattr(variant, 'HGVS_Protein')
+        if is_point_substitution(ref, alt) and is_relevant_position(pos) and has_relevant_protein_change(hgvs_protein):
             '''
             When you submit a position, the mupit server responds with a bunch of structures that the position maps to.
             Which structure to display first is determined client side.

--- a/website/js/MupitStructure.js
+++ b/website/js/MupitStructure.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var content = require('./content');
 var _ = require('underscore');
+var util = require('./util');
 
 
 var mupitStructure = function(variant, prop) {
@@ -15,8 +16,9 @@ class MupitStructure extends React.Component {
     }
     render() {
         let {variant, prop} = this.props;
+        let aminoAcidCode = util.getAminoAcidCode(variant.HGVS_Protein);
         let mupitStructure = _.find(content.mupitStructures, function(structure) {return structure.name === variant[prop].name;});
-        let mupitUrl = mupitStructure.url + "&gm=chr" + variant.Chr + ":" + variant.Pos + "&altaa=" + variant.Alt.toLowerCase();
+        let mupitUrl = mupitStructure.url + "&gm=chr" + variant.Chr + ":" + variant.Pos + "&altaa=" + aminoAcidCode;
         return (
             <div className="mupit-structure">
                 <h5>{variant.Genomic_Coordinate_hg38} in the 3D structure of {mupitStructure.humanReadableName}</h5>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -836,6 +836,16 @@ var VariantDetail = React.createClass({
                 if (prop === "Mupit_Structure") {
                     rowItem = rowDescriptor.replace(variant, prop);
 
+                    /*
+                    Don't display mupit structures if they don't have an associated Amino Acid change.
+                    Note that there shouldn't be mupit structures for these variants in the first place,
+                    but there may be as getAminoAcidCode may change after the database is populated
+                    */
+                    if (util.getAminoAcidCode(variant["HGVS_Protein"]) === false) {
+                        rowsEmpty += 1;
+                        rowItem = false;
+                    }
+
                     // mupit structures are not displayed if they're empty
                     if (rowItem === false) {
                         return false;

--- a/website/js/util.js
+++ b/website/js/util.js
@@ -4,6 +4,33 @@ var React = require('react');
 var moment = require('moment');
 var _ = require('underscore');
 
+
+const AminoAcids = {
+    'ala': 'a',
+    'arg': 'r',
+    'asn': 'n',
+    'asp': 'd',
+    'asx': 'b',
+    'cys': 'c',
+    'glu': 'e',
+    'gln': 'q',
+    'glx': 'z',
+    'gly': 'g',
+    'his': 'h',
+    'ile': 'i',
+    'leu': 'l',
+    'lys': 'k',
+    'met': 'm',
+    'phe': 'f',
+    'pro': 'p',
+    'ser': 's',
+    'thr': 't',
+    'trp': 'w',
+    'tyr': 'y',
+    'val': 'v'
+};
+
+
 function isEmptyField(value) {
     if (Array.isArray(value)) {
         value = value[0];
@@ -152,8 +179,23 @@ function sentenceCase(str) {
     return str.replace(/\b\S/g, (t) => t.toUpperCase() );
 }
 
+function getAminoAcidCode(hgvsProtein) {
+    let trimmedHgvs = hgvsProtein.replace(/[0-9()]/g, '');
+    if (trimmedHgvs.length < 3) {
+        return false;
+    } else {
+        let lastThreeChars = trimmedHgvs.substr(trimmedHgvs.length - 3).toLowerCase();
+        if (!(lastThreeChars in AminoAcids)) {
+            return false;
+        } else {
+            return AminoAcids[lastThreeChars];
+        }
+    }
+}
+
 
 module.exports = {
+    getAminoAcidCode,
     isEmptyField,
     normalizeDateFieldDisplay,
     normalizedFieldDisplay,


### PR DESCRIPTION
Checks for amino acid changes in hgvs protein field. If they introduce a stop codon, are synonymous (no amino acid change), or are noncoding / not missense substitutions (e.g. `p.?`), don't query mupit for them and don't display mupit structures for them.