### PR TITLE
Fixes intronic variants at the boundary of an exon as appearing to be exonic.

### DIFF
--- a/website/js/Splicing.js
+++ b/website/js/Splicing.js
@@ -705,7 +705,8 @@ class Splicing extends React.Component {
             exons.map(exon => ({
                 id: exon.id,
                 span: {
-                    start: Math.min(exon.span.start, exon.span.end),
+                    // the +1 makes the starting bound exclusive
+                    start: Math.min(exon.span.start, exon.span.end) + 1,
                     end: Math.max(exon.span.start, exon.span.end),
                 }
             })),
@@ -744,9 +745,10 @@ class Splicing extends React.Component {
         // --- step 2: identify the region of interest
 
         // identify the highlighted boundary
+        // (variants are defined inclusively in the starting coordinate and exclusively in the ending one)
         const overlappingSegments = segments
             .map((segment, idx) => ({idx: idx, segment: segment}))
-            .filter(({segment}) => overlaps(variantSpan, [segment.span.start, segment.span.end]));
+            .filter(({segment}) => overlaps([variantSpan[0], variantSpan[1] - 1], [segment.span.start, segment.span.end]));
 
         const firstSeg = _.first(overlappingSegments), lastSeg = _.last(overlappingSegments);
 


### PR DESCRIPTION
This PR corrects intronic variants appearing in an exon, which was due previously to considering exon boundaries to be inclusive. In this implementation, exons' starting position and variants' ending position are exclusive. This also corrects an issue with variants that fall at the end of an exon appearing slightly off from the end.

The rendering behavior has been spot-checked against a few variants that fall at the exon-intron boundary, specifically:

- **BRCA1**:
  - start of intron 18-19: c.5153-1G>T (http://brcaexchange.org/variant/90592)
  - end of intron 18-19: c.5152+1G>C (http://brcaexchange.org/variant/102138)
  - start of exon 18: c.5152T>C (http://brcaexchange.org/variant/80882)
  - end of exon 18: c.5075A>T (http://brcaexchange.org/variant/102196)

- **BRCA2**:
  - start of intron 23-24: c.9117+1G>T (http://brcaexchange.org/variant/101168)
  - end of intron 23-24: c.9118-1G>C (http://brcaexchange.org/variant/88823)
  - start of exon 24: c.9118G>T (http://brcaexchange.org/variant/88825)
  - end of exon 24: c.9256G>T (http://brcaexchange.org/variant/101265)
