### PR TITLE
Fix/make hgvs protein mapping more robust

### DIFF
--- a/pipeline/data_merging/brca_pseudonym_generator.py
+++ b/pipeline/data_merging/brca_pseudonym_generator.py
@@ -234,11 +234,15 @@ def main(args):
 
                 # Exceptions related to invalid data
                 data_errors = set(['HGVSParseError', 'HGVSError', 'HGVSInvalidVariantError', 'HGVSUnsupportedOperationError'])
+
                 if error_name not in data_errors:
                     # output some more if exception doesn't seem to be related to invalid data
                     logging.error("Non data error raised")
-                    logging.exception(message)
-            
+                    logging.exception(e)
+
+                if error_name == "DatabaseError":
+                    # Aborting, as it is a transient error in principle, i.e. in one run we might be able to obtain a protein change, in another not, messing up the data diffs
+                    raise EnvironmentError("Issue with UTA database. Aborting")
 
         # Add empty data for each new column to prepare for data insertion by index
         for i in range(len(new_columns_to_append)):

--- a/pipeline/docker/Dockerfile
+++ b/pipeline/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN rm -r /opt/leiden /opt/hgvs /root/.cache
 ARG FORCE_REBUILD=0
 ARG BRCA_GIT_REPO=https://github.com/BRCAChallenge/brca-exchange.git
 ARG BRCA_EXCHANGE_COMMIT=master
-#RUN git clone ${BRCA_GIT_REPO} && cd brca-exchange && git checkout ${BRCA_EXCHANGE_COMMIT}
+RUN git clone ${BRCA_GIT_REPO} && cd brca-exchange && git checkout ${BRCA_EXCHANGE_COMMIT}
 
 COPY run_luigi.sh .
 

--- a/pipeline/docker/Dockerfile
+++ b/pipeline/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN rm -r /opt/leiden /opt/hgvs /root/.cache
 ARG FORCE_REBUILD=0
 ARG BRCA_GIT_REPO=https://github.com/BRCAChallenge/brca-exchange.git
 ARG BRCA_EXCHANGE_COMMIT=master
-RUN git clone ${BRCA_GIT_REPO} && cd brca-exchange && git checkout ${BRCA_EXCHANGE_COMMIT}
+#RUN git clone ${BRCA_GIT_REPO} && cd brca-exchange && git checkout ${BRCA_EXCHANGE_COMMIT}
 
 COPY run_luigi.sh .
 

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,7 +1,8 @@
 backports-abc==0.4
 beautifulsoup4==4.5.1
-biopython==1.67
-bioutils==0.1.4
+biocommons.seqrepo==0.3.5 
+biopython==1.69
+bioutils==0.3.3
 bx-python==0.7.3
 certifi==2016.8.2
 configparser==3.5.0

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -8,7 +8,7 @@ configparser==3.5.0
 CrossMap==0.2.6
 Cython==0.24.1
 docutils==0.12
-hgvs==0.3.7
+hgvs==1.1.2
 lockfile==0.12.2
 luigi==2.2.0
 nose==1.3.7


### PR DESCRIPTION
Exceptions raised during the protein mapping are now all written to a log, as opposed to the previous behaviour, where the brca_pseudonym_generator.py script just crashed in some cases.

Also using hgvs 1.1.2 now.