### PR TITLE
Fixes tooltips not displaying after changes to help documentation

### DIFF
--- a/website/content/help/default/variant-details-fields.md
+++ b/website/content/help/default/variant-details-fields.md
@@ -8,8 +8,11 @@ The Expert Reviewed Data Portal contains an abridged view of the variant data in
 
 * #### Gene ((Gene_Symbol))
   The name of the gene on which the variant was found, as named by the HGNC. This will be either _BRCA1_ or _BRCA2_.
+
 * #### HGVS Nomenclature
-    A nomenclature system standardized by the Human Genome Variation Society \(HGVS\) which utilizes coordinates to name variants across genomic DNA, coding DNA, RNA, and protein molecules. Each coordinate provides an indicator of the biomolecule being referred to \('c.', 'g.', 'p.'\), a location in that biomolecule \('12345'\), and an indication of what changed in the variant \('G&gt;A', 'insA', 'dupT', 'del15', 'Asp...Asn'\). Most variant aliases utilize this standard nomenclature:
+    A nomenclature system standardized by the Human Genome Variation Society \(HGVS\) which utilizes coordinates to name variants across genomic DNA, coding DNA, RNA, and protein molecules.
+
+    Each coordinate provides an indicator of the biomolecule being referred to \('c.', 'g.', 'p.'\), a location in that biomolecule \('12345'\), and an indication of what changed in the variant \('G&gt;A', 'insA', 'dupT', 'del15', 'Asp...Asn'\). Most variant aliases utilize this standard nomenclature:
   * #### HGVS Nucleotide ((HGVS_cDNA))
     HGVS variant alias which references the nucleotide change based on the location in the coding DNA, not the genomic DNA.
   * #### HGVS RNA ((HGVS_RNA))

--- a/website/content/help/research/variant-nomenclature.md
+++ b/website/content/help/research/variant-nomenclature.md
@@ -1,5 +1,9 @@
+<span class="term_entry">
+
 #### Gene ((Gene_Symbol))
 The name of the gene on which the variant was found, as named by the HGNC. This will be either _BRCA1_ or _BRCA2_.
+
+</span>
 
 ----
 #### HGVS Nomenclature
@@ -18,15 +22,29 @@ A nomenclature system standardized by the Human Genome Variation Society \(HGVS\
 
 ----
 
+<span class="term_entry">
+
 #### Transcript Identifier ((Reference_Sequence))
-These identifiers, which typically start in ‘NM’, are gene-specific, not variant-specific. They are generally used to keep track of different transcripts submitted to databases such as RefSeq, and are carried over to ClinVar. BRCA Exchange mainly uses two transcript identifiers. There is one main transcript used for _BRCA1_ \(NM 007294.3\) and another identifier used for _BRCA2_ \(NM 000059.3\). Other, less common transcripts are also present in the database.
+These identifiers, which typically start in ‘NM’, are gene-specific, not variant-specific. They are generally used to keep track of different transcripts submitted to databases such as RefSeq, and are carried over to ClinVar.
+
+BRCA Exchange mainly uses two transcript identifiers. There is one main transcript used for _BRCA1_ \(NM 007294.3\) and another identifier used for _BRCA2_ \(NM 000059.3\). Other, less common transcripts are also present in the database.
+
+</span>
 
 ----
+
+<span class="term_entry">
 
 #### Abbreviated AA Change ((Protein_Change))
 A shortened abbreviation of the HGVS Protein alias using one-letter abbreviation for amino acids.
 
+</span>
+
 ----
+
+<span class="term_entry">
 
 #### BIC designation ((BIC_Nomenclature))
 A variant alias presented in BIC Nomenclature, which predates HGVS nomenclature and thus follows a different format.
+
+</span>

--- a/website/js/content.js
+++ b/website/js/content.js
@@ -302,7 +302,7 @@ function parseTooltips(isResearchMode) {
     const nodes = flattenDeep(findContentNodes(isResearchMode ? helpContentResearch : helpContentDefault));
 
     // merge all the nodes' respective dictionaries into one master dictionary
-    return _.reduce(nodes.map(node => parseContentForTips(node), _.extend));
+    return _.reduce(nodes.map(node => parseContentForTips(node)), _.extend);
 }
 
 module.exports = {

--- a/website/js/content.js
+++ b/website/js/content.js
@@ -255,7 +255,7 @@ function findContentNodes(head) {
             return head.list.map(x => findContentNodes(x));
         }
         else if (head.contents !== undefined) {
-            return { name: head.name, contents: head.contents };
+            return head.contents;
         }
     }
 }
@@ -273,15 +273,12 @@ function extractNonHeaders(x) {
     return result.html().trim();
 }
 
-function parseContentForTips(name, helpContent) {
-    /*
-    const helpElem = document.createElement('html');
-    helpElem.innerHTML = helpContent;
-    */
+function parseContentForTips(helpContent) {
     // we enclose the payload in a div because otherwise jQuery can't find top-level elements in the blob
     const helpElem = jQuery.parseHTML("<div>" + helpContent + "</div>");
 
-    // the glossary's kind of implemented as lis with nested h4s with ids followed by some text within the same parent
+    // the glossary's formatted as lis with nested h4s or h5s with ids followed by some text within the same parent
+    // in rare cases where the terms aren't in a list, we also look for an explicit <span class="term_entry"> tag
     const extracted = jQuery("li,span.term_entry", helpElem).find("h4,h5").map((idx, x) => {
         const $x = jQuery(x);
         const helpText = extractNonHeaders($x);
@@ -305,7 +302,7 @@ function parseTooltips(isResearchMode) {
     const nodes = flattenDeep(findContentNodes(isResearchMode ? helpContentResearch : helpContentDefault));
 
     // merge all the nodes' respective dictionaries into one master dictionary
-    return _.reduce(nodes.map(node => parseContentForTips(node.name, node.contents)), _.extend);
+    return _.reduce(nodes.map(node => parseContentForTips(node), _.extend));
 }
 
 module.exports = {


### PR DESCRIPTION
Addresses issue #837.

Modifies parsing code to recursively descend into new help docs structure, looking for markdown. The scraper now looks for `<h5>` tags in addition to `<h4>` tags, and can look for an explicitly denoted `<span class="term_entry" />` tag instead of just `<li>`'s with nested `<h4>`'s (the previous term-definition format). Modified help content in cases where it wasn't possible to automatically parse out the terms.

I made a few small formatting changes, too, like adding newlines to break up large blocks of text. Since the tooltip uses only the first paragraph of the text, the change in `content/help/research/variant-nomenclature.md` to `Reference_Sequence` does affect what's shown in the tooltip for that field.