### PR TITLE
Field names now properly open the panel they target when clicked

### DIFF
--- a/website/js/Help.js
+++ b/website/js/Help.js
@@ -69,15 +69,15 @@ const Help = React.createClass({
         }
     },
 
-    shouldBeExpanded(fragment, {name, id, contents, list}) {
+    shouldBeExpanded(fragment, fragRegex, {name, id, contents, list}) {
         let slug = id || slugify(name);
         if (slug === fragment) {
             return true;
         }
-        if (contents && contents.includes(`id="${fragment}"`)) {
+        if (contents && fragRegex.test(contents)) {
             return true;
         }
-        if (list && list.some(elem => this.shouldBeExpanded(fragment, elem))) {
+        if (list && list.some(elem => this.shouldBeExpanded(fragment, fragRegex, elem))) {
             return true;
         }
         return false;
@@ -87,6 +87,9 @@ const Help = React.createClass({
         let help = localStorage.getItem("research-mode") === 'true' ? content.helpContentResearch : content.helpContentDefault;
 
         var fragment = slugify(window.location.hash.slice(1));
+        // looks for the fragment within id attributes wrapped in quotes (in dev) or without quotes (minified)
+        // we compile it once here and pass the same regex to each call to shouldBeExpanded() to save a little time
+        const fragRegex = new RegExp(`(id=${fragment}|id="${fragment})"`);
 
         var helpTiles = help.map(({section, tiles}) =>
             [<h1>{section}</h1>, tiles.map(({name, id, contents, list, reference}) => {
@@ -107,7 +110,7 @@ const Help = React.createClass({
                     body.push(
                         <ListGroup fill>
                             { list.map(({name, id, contents}) =>
-                                <CollapsableListItem defaultExpanded={this.shouldBeExpanded(fragment, {name, id, contents})}
+                                <CollapsableListItem defaultExpanded={this.shouldBeExpanded(fragment, fragRegex, {name, id, contents})}
                                                      id={id ? id : slugify(name)}
                                                      header={name}>
                                     <RawHTML html={contents} />
@@ -126,7 +129,7 @@ const Help = React.createClass({
                     );
                 }
                 return (<Panel header={header} collapsable={true}
-                               defaultExpanded={this.shouldBeExpanded(fragment, {name, id, contents, list})}
+                               defaultExpanded={this.shouldBeExpanded(fragment, fragRegex, {name, id, contents, list})}
                                onSelect={onSelect}
                         >
                     { body }


### PR DESCRIPTION
Fixes an issue where panels weren't expanding if they were referenced in the fragment on production. This appeared to be due to the minifier stripping double quotes around attributes values, causing the check for id="fragment" in the panel to fail.