### PR TITLE
Field links expand the targeted help section

### DIFF
--- a/website/js/Help.js
+++ b/website/js/Help.js
@@ -89,7 +89,7 @@ const Help = React.createClass({
         var fragment = slugify(window.location.hash.slice(1));
         // looks for the fragment within id attributes wrapped in quotes (in dev) or without quotes (minified)
         // we compile it once here and pass the same regex to each call to shouldBeExpanded() to save a little time
-        const fragRegex = new RegExp(`(id=${fragment}|id="${fragment})"`);
+        const fragRegex = new RegExp(`(id=${fragment}|id="${fragment}")`);
 
         var helpTiles = help.map(({section, tiles}) =>
             [<h1>{section}</h1>, tiles.map(({name, id, contents, list, reference}) => {


### PR DESCRIPTION
Due to a difference in minification settings between dev and production, the code that handles expanding the help section when the user clicks a field name was failing; specifically, it was looking for id="<fragment>", but minification in production was removing the surrounding quotes in the attribute's value and producing id=<fragment> instead. The first attempt to fix this had a misplaced quote in the regex, which was causing the regex to fail to match it. This PR puts the quote in the right place. It's been tested with both the dev and production webpack configs and works in both.