### PR TITLE
Fixes #846, mupit tile obscured

### DIFF
--- a/website/js/MupitStructure.js
+++ b/website/js/MupitStructure.js
@@ -1,34 +1,28 @@
 'use strict';
 
-var React = require('react');
-var content = require('./content');
-var _ = require('underscore');
-var util = require('./util');
+const React = require('react');
+const content = require('./content');
+const _ = require('underscore');
+const util = require('./util');
 
-
-var mupitStructure = function(variant, prop) {
-    return <MupitStructure variant={variant} prop={prop} />;
-};
-
-class MupitStructure extends React.Component {
+export default class MupitStructure extends React.Component {
     constructor(props) {
         super(props);
     }
     render() {
-        let {variant, prop} = this.props;
-        let aminoAcidCode = util.getAminoAcidCode(variant.HGVS_Protein);
-        let mupitStructure = _.find(content.mupitStructures, function(structure) {return structure.name === variant[prop].name;});
-        let mupitUrl = mupitStructure.url + "&gm=chr" + variant.Chr + ":" + variant.Pos + "&altaa=" + aminoAcidCode;
+        const {variant, prop} = this.props;
+        const aminoAcidCode = util.getAminoAcidCode(variant.HGVS_Protein);
+        const mupitStructure = _.find(content.mupitStructures, function(structure) {return structure.name === variant[prop].name;});
+        const mupitUrl = mupitStructure.url + "&gm=chr" + variant.Chr + ":" + variant.Pos + "&altaa=" + aminoAcidCode;
+
         return (
             <div className="mupit-structure">
                 <h5>{variant.Genomic_Coordinate_hg38} in the 3D structure of {mupitStructure.humanReadableName}</h5>
                 <a href={mupitUrl} target="_blank">
-                    <img src={mupitStructure.image}></img>
+                    <img src={mupitStructure.image} onLoad={this.props.onLoad} />
                 </a>
                 <p>Click on this thumbnail to open MuPIT viewer from the CRAVAT project, and view the variant in a 3D protein structure context.</p>
             </div>
         );
     }
 }
-
-module.exports = mupitStructure;

--- a/website/js/Splicing.js
+++ b/website/js/Splicing.js
@@ -672,7 +672,7 @@ class Splicing extends React.Component {
             localStorage.setItem("transcriptviz-options-expanded", this.state.optionsExpanded ? "true" : "false");
 
             // reflows the parent after our dimensions change
-            this.props.onContentsChanged();
+            this.props.onContentsChanged(this.collapser.getCollapsableDOMNode());
         });
     }
 
@@ -776,6 +776,7 @@ class Splicing extends React.Component {
                 </svg>
 
                 <SettingsPanel
+                    ref={(me) => { this.collapser = me; }}
                     key="settings-panel"
                     meta={meta}
                     expanded={this.state.optionsExpanded}

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -21,7 +21,6 @@ var ColumnCheckbox = require('./ColumnCheckbox');
 var {getDefaultExpertColumns, getDefaultResearchColumns, getAllSources} = require('./VariantTableDefaults');
 var {State} = require('react-router');
 var alleleFrequencyCharts = require('./AlleleFrequencyCharts');
-var mupitStructure = require('./MupitStructure');
 
 require('react-data-components-bd2k/css/table-twbs.css');
 
@@ -234,7 +233,7 @@ const researchModeGroups = [
     ]},
 
     {groupTitle: 'CRAVAT - MuPIT 3D Protein View', internalGroupName: 'Mupit Structure', innerCols: [
-        {title: 'Mupit Structure', prop: 'Mupit_Structure', replace: mupitStructure, tableKey: false, dummy: true}
+        {title: 'Mupit Structure', prop: 'Mupit_Structure', tableKey: false, dummy: true}
     ]},
 ];
 

--- a/website/js/components/AlleleFrequenciesTile.js
+++ b/website/js/components/AlleleFrequenciesTile.js
@@ -38,7 +38,7 @@ export default class AlleleFrequenciesTile extends React.Component {
             return updatedFieldsOfInterest;
         }, () => {
             // causes the parent to perform a (delayed) reflow
-            this.props.onFrequencyFieldToggled();
+            this.props.onFrequencyFieldToggled(this.collapser.getCollapsableDOMNode());
         });
     }
 
@@ -47,7 +47,7 @@ export default class AlleleFrequenciesTile extends React.Component {
             [fieldName]: !this.state[fieldName]
         }, () => {
             // causes the parent to perform a (delayed) reflow
-            this.props.onFrequencyFieldToggled();
+            this.props.onFrequencyFieldToggled(this.collapser.getCollapsableDOMNode());
         });
     }
 
@@ -125,6 +125,7 @@ export default class AlleleFrequenciesTile extends React.Component {
         return (
             <div key={`group_collection-${groupTitle}`} className={ allEmpty && this.props.hideEmptyItems ? "group-empty variant-detail-group" : "variant-detail-group" }>
                 <Panel
+                    ref={(me) => { this.collapser = me; }}
                     header={header}
                     collapsable={true}
                     defaultExpanded={localStorage.getItem("collapse-group_" + groupTitle) !== "true"}

--- a/website/js/components/SourceReportsTile.js
+++ b/website/js/components/SourceReportsTile.js
@@ -65,7 +65,7 @@ export default class SourceReportsTile extends React.Component {
             reportExpanded: Array.from({ length: this.props.submissions.length }, () => newExpansion)
         }, () => {
             // causes the parent to perform a (delayed) reflow
-            this.props.onReportToggled();
+            this.props.onReportToggled(this.collapser.getCollapsableDOMNode());
         });
     }
 
@@ -75,7 +75,7 @@ export default class SourceReportsTile extends React.Component {
             reportExpanded: pstate.reportExpanded.map((x, j) => (idx === j) ? !x : x)
         }), () => {
             // causes the parent to perform a (delayed) reflow
-            this.props.onReportToggled();
+            this.props.onReportToggled(this.collapser.getCollapsableDOMNode());
         });
     };
 
@@ -150,6 +150,7 @@ export default class SourceReportsTile extends React.Component {
         return (
             <div key={`group_collection-${groupTitle}`} className="variant-detail-group variant-submitter-group">
                 <Panel
+                    ref={(me) => { this.collapser = me; }}
                     header={header}
                     collapsable={true}
                     defaultExpanded={localStorage.getItem("collapse-group_" + groupTitle) !== "true"}>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -32,7 +32,8 @@ var moment = require('moment');
 // faisal: includes for masonry/isotope
 var Isotope = require('isotope-layout');
 require('isotope-packery');
-
+import TransitionEvents from 'react/lib/ReactTransitionEvents';
+import debounce from 'lodash/debounce';
 
 var brcaLogo = require('./img/BRCA-Exchange-tall-tranparent.png');
 var logos = require('./logos');
@@ -441,7 +442,7 @@ function isEmptyDiff(value) {
 const IsoGrid = React.createClass({
     displayName: 'IsoGrid',
 
-    // Wrapper to layout child elements passed in
+    // wraps contents in a masonry-managed container
     render: function () {
         const children = this.props.children;
         return (
@@ -451,23 +452,9 @@ const IsoGrid = React.createClass({
         );
     },
 
-    // When the DOM is rendered, let Masonry know what's changed
-    componentDidUpdate: function() {
-        if (this.masonry) {
-            var that = this;
-            setTimeout(() => {
-                // prevents improper layout of mupit tile, and potentially others
-                // 300ms is the time it takes for the tile to expand
-                that.masonry.reloadItems();
-                that.masonry.arrange();
-            }, 300);
-        }
-    },
-
-    // Set up Masonry
+    // create masonry object to manage children's positions
     componentDidMount: function() {
-        if(!this.masonry) {
-            // i suppose we're doing this so the children exist when we create it?
+        if (!this.masonry) {
             this.masonry = new Isotope('.isogrid', {
                 layoutMode: 'packery',
                 itemSelector: '.isogrid-item',
@@ -477,10 +464,14 @@ const IsoGrid = React.createClass({
                 }
             });
         }
-        else {
+    },
+
+    relayout: function(fullRefresh) {
+        if (fullRefresh) {
             this.masonry.reloadItems();
-            this.masonry.arrange();
         }
+
+        this.masonry.arrange();
     }
 });
 
@@ -498,7 +489,7 @@ var VariantDetail = React.createClass({
     componentWillMount: function () {
         backend.variant(this.props.params.id).subscribe(
             resp => {
-                return this.setState({data: resp.data, error: null});
+                this.setState({data: resp.data, error: null});
             },
             () => { this.setState({error: 'Problem connecting to server'}); }
         );
@@ -508,20 +499,31 @@ var VariantDetail = React.createClass({
                 // we always want reports grouped by source, so we'll do so centrally here
                 const groupedReports = _.groupBy(resp.data, 'Source');
 
-                return this.setState({reports: groupedReports, error: null});
+                this.setState({reports: groupedReports, error: null}, () => {
+                    this.relayoutGrid();
+                });
             }, () => {
                 this.setState({reportError: 'Problem retrieving reports'});
                 console.warn("Couldn't retrieve reports!");
             }
         );
+
     },
-    onChildToggleMode: function() {
-        this.props.toggleMode();
-        // we need to reparse the tooltips if the mode changed
-        this.setState({
-            tooltips: parseTooltips(localStorage.getItem("research-mode") === 'true')
-        });
-        this.forceUpdate();
+    componentWillUpdate: function(nextProps) {
+        // reparse the tooltips since they're mode-specific
+        if (nextProps.mode !== this.props.mode) {
+            this.setState({
+                tooltips: parseTooltips(nextProps.mode === 'research_mode')
+            });
+        }
+    },
+    componentDidUpdate: function(prevProps) {
+        if (prevProps.mode !== this.props.mode) {
+            // if the mode changed, we have to relayout the page on the next available frame
+            setTimeout(() => {
+                this.relayoutGrid(true);
+            }, 0);
+        }
     },
     pathogenicityChanged: function(pathogenicityDiff) {
         return (pathogenicityDiff.added || pathogenicityDiff.removed) ? true : false;
@@ -531,6 +533,8 @@ var VariantDetail = React.createClass({
 
         this.setState({
             hideEmptyItems: hideEmptyItems
+        }, () => {
+            this.relayoutGrid();
         });
     },
     truncateData: function(field) {
@@ -541,6 +545,19 @@ var VariantDetail = React.createClass({
             return false;
         }
     },
+    relayoutGrid: debounce(function(fullRefresh) {
+        if (this.isogrid) {
+            this.isogrid.relayout(fullRefresh);
+        }
+    }),
+    relayoutOnCollapsed: function(collapser) {
+        // this will relayout the page when the animation is finished
+        const endHandler = () => {
+            TransitionEvents.removeEndEventListener(collapser, endHandler);
+            this.relayoutGrid();
+        };
+        TransitionEvents.addEndEventListener(collapser, endHandler);
+    },
     onChangeGroupVisibility(groupTitle, event) {
         // stop the page from scrolling to the top (due to navigating to the fragment '#')
         event.preventDefault();
@@ -548,7 +565,6 @@ var VariantDetail = React.createClass({
         // the event target is actually the span *inside* the 'a' tag, but we need to check the 'a' tag for the
         // collapsed state
         const collapsingElemParent = event.target.parentElement;
-
         let willBeCollapsed = true;
 
         collapsingElemParent.childNodes.forEach(function(child) {
@@ -561,15 +577,9 @@ var VariantDetail = React.createClass({
         });
         localStorage.setItem("collapse-group_" + groupTitle, willBeCollapsed);
 
-        // defer re-layout until the state change has completed
-        const me = this;
-
-        setTimeout(() => {
-            // this forces a re-render after a group has expanded/collapsed, fixing the layout
-            // note that 300ms just happens to be the duration of the expand/collapse animation
-            // it'd be better to run the re-layout whenever the animation ends
-            me.forceUpdate();
-        }, 300);
+        // find the actual collapsing DOM element so we can attach a handler to its transition-end event
+        const collapser = collapsingElemParent.parentElement.parentElement.getElementsByClassName("panel-collapse")[0];
+        this.relayoutOnCollapsed(collapser);
     },
     determineDiffRowColor: function(highlightRow) {
         return highlightRow ? 'danger' : '';
@@ -692,7 +702,7 @@ var VariantDetail = React.createClass({
             cols,
             groups;
 
-        if (localStorage.getItem("research-mode") === 'true') {
+        if (this.props.mode === 'research_mode') {
             cols = researchModeColumns;
             groups = researchModeGroups;
         } else {
@@ -731,13 +741,8 @@ var VariantDetail = React.createClass({
                         submissions={this.state.reports[reportSource]}
                         onChangeGroupVisibility={this.onChangeGroupVisibility}
                         hideEmptyItems={this.state.hideEmptyItems}
-                        onReportToggled={() => {
-                            setTimeout(() => {
-                                // this forces a re-render after a group has expanded/collapsed, fixing the layout
-                                // note that 300ms just happens to be the duration of the expand/collapse animation
-                                // it'd be better to run the re-layout whenever the animation ends
-                                this.forceUpdate();
-                            }, 300);
+                        onReportToggled={(collapser) => {
+                            this.relayoutOnCollapsed(collapser);
                         }}
                         showHelp={this.showHelp}
                         tooltips={this.state.tooltips}
@@ -752,13 +757,8 @@ var VariantDetail = React.createClass({
                         groupTitle={groupTitle}
                         onChangeGroupVisibility={this.onChangeGroupVisibility}
                         hideEmptyItems={this.state.hideEmptyItems}
-                        onFrequencyFieldToggled={() => {
-                            setTimeout(() => {
-                                // this forces a re-render after a group has expanded/collapsed, fixing the layout
-                                // note that 300ms just happens to be the duration of the expand/collapse animation
-                                // it'd be better to run the re-layout whenever the animation ends
-                                this.forceUpdate();
-                            }, 300);
+                        onFrequencyFieldToggled={(collapser) => {
+                            this.relayoutOnCollapsed(collapser);
                         }}
                         showHelp={this.showHelp}
                         tooltips={this.state.tooltips}
@@ -870,7 +870,8 @@ var VariantDetail = React.createClass({
                     <Panel
                         header={header}
                         collapsable={true}
-                        defaultExpanded={localStorage.getItem("collapse-group_" + groupTitle) !== "true"}>
+                        defaultExpanded={localStorage.getItem("collapse-group_" + groupTitle) !== "true"}
+                    >
                         <Table>
                             <tbody>
                                 {rows}
@@ -992,6 +993,11 @@ var VariantDetail = React.createClass({
             </h3>
         );
 
+        const tileSizeClasses = groupTables.length < 3
+            ? `col-xs-12 col-md-${12 / groupTables.length}`
+            : `col-xs-12 col-md-6 col-lg-6 col-xl-4`;
+        const splicingTileSizeClassse = 'col-xs-12 col-md-12 col-lg-12 col-xl-8';
+
         return (error ? <p>{error}</p> :
             <Grid>
                 <Row>
@@ -1023,49 +1029,41 @@ var VariantDetail = React.createClass({
 
                 <Row>
                     <div className="container-fluid variant-details-body">
-                        { (groupTables.length < 3) ?
-                            <IsoGrid>
-                                <div className={`isogrid-sizer col-xs-12 col-md-${12 / groupTables.length}`}/>
-                                {
-                                    groupTables.map((x, i) => {
-                                        return (
-                                            <Col key={"group_col-" + i} xs={12} md={12 / groupTables.length}
-                                                className="variant-detail-group isogrid-item">
-                                                {x}
-                                            </Col>
-                                        );
-                                    })
-                                }
-                            </IsoGrid>
-                            :
-                            <IsoGrid>
-                                <div className="isogrid-sizer col-xs-12 col-md-6 col-lg-6 col-xl-4"/>
-                                    <Col key={"splicing_vis"} xs={12} md={12} lg={12} className="variant-detail-group isogrid-item col-xl-8">
-                                        <Panel header={splicingHeader} collapsable={true} defaultExpanded={localStorage.getItem("collapse-group_transcript-visualization") !== "true"}>
+                        <IsoGrid ref={ (me) => { this.isogrid = me; } }>
+                            <div className={`isogrid-sizer ${tileSizeClasses}`} />
+
+                            {
+                                // show the splicing vis if we're in research mode
+                                this.props.mode === "research_mode" && (
+                                    <Col key="splicing_vis"
+                                        className={`variant-detail-group isogrid-item ${splicingTileSizeClassse}`}>
+                                        <Panel
+                                            header={splicingHeader}
+                                            collapsable={true}
+                                            defaultExpanded={localStorage.getItem("collapse-group_transcript-visualization") !== "true"}
+                                        >
                                             <Splicing variant={variant}
-                                                onContentsChanged={() => {
-                                                    setTimeout(() => {
-                                                        // this forces a re-render after a group has expanded/collapsed, fixing the layout
-                                                        // the 0 timeout will run this once the queue is empty, i.e. after the animation has completed
-                                                        this.forceUpdate();
-                                                    }, 0);
+                                                onContentsChanged={(collapser) => {
+                                                    this.relayoutOnCollapsed(collapser);
                                                 }}
                                             />
                                         </Panel>
                                     </Col>
-                                {
-                                    // we're mapping each group into a column so we can horizontally stack them
-                                    groupTables.map((x, i) => {
-                                        return (
-                                            <Col key={"group_col-" + i} xs={12} md={6} lg={6}
-                                                className="variant-detail-group isogrid-item col-xl-4">
-                                                {x}
-                                            </Col>
-                                        );
-                                    })
-                                }
-                            </IsoGrid>
-                        }
+                                )
+                            }
+
+                            {
+                                // we're mapping each group into a column so we can horizontally stack them
+                                groupTables.map((x, i) => {
+                                    return (
+                                        <Col key={"group_col-" + i}
+                                            className={`variant-detail-group isogrid-item ${tileSizeClasses}`}>
+                                            {x}
+                                        </Col>
+                                    );
+                                })
+                            }
+                        </IsoGrid>
                     </div>
                 </Row>
 
@@ -1094,7 +1092,7 @@ var VariantDetail = React.createClass({
 
                 <Row>
                     <Col md={12} mdOffset={0}>
-                        <DisclaimerModal buttonModal onToggleMode={this.onChildToggleMode} text="Show All Public Data on this Variant"/>
+                        <DisclaimerModal buttonModal onToggleMode={this.props.toggleMode} text="Show All Public Data on this Variant"/>
                     </Col>
                 </Row>
             </Grid>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -2,10 +2,12 @@
 /*global require: false */
 'use strict';
 
-// shims for older browsers
+
 import SourceReportsTile from "./components/SourceReportsTile";
 import AlleleFrequenciesTile from "./components/AlleleFrequenciesTile";
+import MupitStructure from './MupitStructure';
 
+// shims for older browsers
 require('babel/polyfill');
 require('es5-shim');
 require('es5-shim/es5-sham');
@@ -787,7 +789,7 @@ var VariantDetail = React.createClass({
 
                 // get mupit structures if they're available
                 if (prop === "Mupit_Structure") {
-                    rowItem = rowDescriptor.replace(variant, prop);
+                    rowItem = <MupitStructure variant={variant} prop={prop} onLoad={() => this.relayoutGrid()} />;
 
                     /*
                     Don't display mupit structures if they don't have an associated Amino Acid change.
@@ -816,7 +818,9 @@ var VariantDetail = React.createClass({
                     rowItem = util.getFormattedFieldByProp(prop, variant);
                 }
 
-                let isEmptyValue = rowDescriptor.replace ? rowItem === false : util.isEmptyField(variant[prop]);
+                let isEmptyValue = (rowDescriptor.replace || rowDescriptor.dummy)
+                    ? rowItem === false
+                    : util.isEmptyField(variant[prop]);
 
                 if (title === "Beacons") {
                     if (variant.Ref.length > 1 || variant.Alt.length > 1) {


### PR DESCRIPTION
With respect to fixing issue #846, this PR adds an `onLoad` handler to the MupitStructure component, which triggers a tile relayout when the image inside the component loads. (The image loading a little late was previously causing it to change height after the initial relayout completed, causing the tile to be truncated.) In order to supply a callback for this extra prop, the MupitStructure component is now explicitly instantiated instead of via VariantTable's `replace` field. Rows which either have a truthy `replace` field or truthy `dummy` field will now be considered non-empty, since Mupit no longer uses `replace`, but does have `dummy: true`.

This PR also overhauls the tile relayout code that was previously implemented via a pretty inefficient mechanism that required redrawing the entire contents of the `VariantDetail` component with each relayout request. The new mechanism now only calls Isotope's `arrange()` method rather than using `forceUpdate()` or any other React re-rendering method. This new mechanism is now invoked when tile collapse/expand animations *actually* end (instead of trying to guess when they'd end via a precisely-timed `setTimeout()` call). It is also invoked directly instead of via `forceUpdate()`, which had previously triggered the IsoGrid component's `componentDidUpdate()` method, indirectly causing a tile relayout.

There were a few minor code-style changes as well, e.g. switching `let` to `const` when possible and fixing inconsistent indentation.