### PR TITLE
update url to resource files

### DIFF
--- a/pipeline/data/getdata
+++ b/pipeline/data/getdata
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-URL=http://hgwdev.soe.ucsc.edu/~cline/BRCA/resources
+URL=http://brcaexchange.org/backend/downloads/resources
 HASH=sha1sum
 
 declare -A files


### PR DESCRIPTION
resource files previously located on hgwdev are now available through brcaexchange.org