### PR TITLE
Fixes #855, help panels being expanded if no fragment is specified

### DIFF
--- a/website/js/Help.js
+++ b/website/js/Help.js
@@ -70,6 +70,10 @@ const Help = React.createClass({
     },
 
     shouldBeExpanded(fragment, fragRegex, {name, id, contents, list}) {
+        if (!fragment) {
+            return false;
+        }
+
         let slug = id || slugify(name);
         if (slug === fragment) {
             return true;

--- a/website/js/Help.js
+++ b/website/js/Help.js
@@ -70,6 +70,8 @@ const Help = React.createClass({
     },
 
     shouldBeExpanded(fragment, fragRegex, {name, id, contents, list}) {
+        // if fragment is empty, fragRegex will be (id=|id=""), which will match anything containing 'id='
+        // if there isn't a fragment, then we should never expand anything by default anyway, so just bail w/false
         if (!fragment) {
             return false;
         }


### PR DESCRIPTION
Fixes a bug introduced in commit e858b72afe3122e5d93aaf2b2e969691a68ce45c in which specifying an empty fragment would cause the regex that looks for `(id=<fragment>|id="<fragment>") to match sections with just `id=` in them, causing those panels to be incorrectly expanded by default.

The panel expansion test returns false immediately if no fragment is specified, since no panel should be expanded if the fragment is empty anyway.