### PR TITLE
Fixes #845, panel header help links not showing relevant part of help page

### DIFF
--- a/website/js/Help.js
+++ b/website/js/Help.js
@@ -99,7 +99,7 @@ const Help = React.createClass({
 
         var helpTiles = help.map(({section, tiles}) =>
             [<h1>{section}</h1>, tiles.map(({name, id, contents, list, reference}) => {
-                let header = [name];
+                let header = [<span id={id || slugify(name)}>{name}</span>];
                 // if the user clicks a reference link in a tile header, don't toggle the tile, and open the link.
                 let onSelect = function (e) {
                     if (e.target.classList.contains("help-reference-link")) {

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -692,7 +692,7 @@ html {
 
 @keyframes emphasis {
 	from {background-color: bisque;}
-	to {background-color: white;}
+	to {background-color: transparent;}
 }
 
 th[role='columnheader']:hover .help, .help-target:hover .help {


### PR DESCRIPTION
Addresses issue #845.

Added an ID to panel headers so that they can be targeted by the fragment. The highlight animation was also fading to white, which resulted in a blotch on the non-white background of the panel header, so I changed it to fade to transparent instead.