### PR TITLE
Improves tile collapsing detection in VariantDetail

### DIFF
--- a/website/js/index.js
+++ b/website/js/index.js
@@ -562,20 +562,9 @@ var VariantDetail = React.createClass({
         // stop the page from scrolling to the top (due to navigating to the fragment '#')
         event.preventDefault();
 
-        // the event target is actually the span *inside* the 'a' tag, but we need to check the 'a' tag for the
-        // collapsed state
-        const collapsingElemParent = event.target.parentElement;
-        let willBeCollapsed = true;
-
-        collapsingElemParent.childNodes.forEach(function(child) {
-            // FIXME: there must be a better way to get at the panel's state than reading the class
-            // Maybe we'll subclass Panel and let it handle its own visibility persistence.
-            if (child.getAttribute("class") === "collapsed") {
-                // if it's already collapsed, this method should expand it
-                willBeCollapsed = false;
-            }
-        });
-        localStorage.setItem("collapse-group_" + groupTitle, willBeCollapsed);
+        // if there's no existing key or if it's not true, this group is visible and thus collapsing
+        const willBeCollapsed = localStorage.getItem("collapse-group_" + groupTitle) !== "true";
+        localStorage.setItem("collapse-group_" + groupTitle, willBeCollapsed ? "true" : "false");
 
         this.relayoutOnCollapsed(collapser);
     },


### PR DESCRIPTION
Fixes #862, specifically fixing the upcoming ISPP tile's collapsing persistence. It now checks the prior collapse state for the group in local storage instead of traversing the DOM to find a collapsed component inside the panel, which breaks for tiles that don't have the same DOM layout as the other panels, e.g. the ISPP tile.

Tested collapsing/expanding each tile and refreshing to ensure that the changes persisted, both with existing collapsed states in local storage and not. Also tested with triggering the refresh at different points in the collapsing animation.