### PR TITLE
Integrate priors into pipeline

### DIFF
--- a/pipeline/docker/Dockerfile
+++ b/pipeline/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN curl -fsSL get.docker.com -o get-docker.sh \
 WORKDIR /opt
 
 COPY requirements_docker.txt .
-COPY test-requirements_docker.txt .
 
 # install numpy first to avoid issues with bio python and bx-python (see also https://github.com/LUMC/vep2lovd/issues/1)
 RUN pip install $(grep numpy requirements_docker.txt)

--- a/pipeline/docker/Dockerfile
+++ b/pipeline/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -fsSL get.docker.com -o get-docker.sh \
 WORKDIR /opt
 
 COPY requirements_docker.txt .
+COPY test-requirements_docker.txt .
 
 # install numpy first to avoid issues with bio python and bx-python (see also https://github.com/LUMC/vep2lovd/issues/1)
 RUN pip install $(grep numpy requirements_docker.txt)

--- a/pipeline/docker/Dockerfile
+++ b/pipeline/docker/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update && apt-get install -y \
     wget \
     zlib1g-dev
 
+# Get the Docker binary
+RUN curl -fsSL get.docker.com -o get-docker.sh \
+    && sh get-docker.sh
+
 WORKDIR /opt
 
 COPY requirements_docker.txt .
@@ -40,7 +44,7 @@ ENV BRCA_RESOURCES=$res
 
 RUN mkdir -p $res /files/data && chmod -R o+rwx /files
 
-RUN mkdir -p /.synapseCache && chmod o+rwx /.synapseCache  
+RUN mkdir -p /.synapseCache && chmod o+rwx /.synapseCache
 
 RUN git clone https://github.com/counsyl/hgvs.git
 # taking pyhgvs 0.9.4

--- a/pipeline/docker/README.md
+++ b/pipeline/docker/README.md
@@ -47,13 +47,16 @@ Notes:
 * The line concerning the DATA_DATE can be omitted. If provided, it explicitly sets the date of the pipeline run rather than using the current date (e.g. this is useful when rerunning a pipeline that aborted half way through).
 * The line concerning UTA_DB_URL can be used to run a local instance of a uta database. This is helpful if a remote instance is having issues. See https://github.com/biocommons/uta/#installing-uta-locally for information on getting a local instance of a uta database running.
 * The line concerning network is used to connect to the uta container, which exposes a port on 50827 from within the pipeline container.
+* The line concerning docker.sock maps the host operating system's docker socket into the container so that the client in the luigi container talks to the single os's daemon.
 
 ```
 docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) \
        -e "DATA_DATE=${DATA_DATE}" \
        --network host \
        -e "UTA_DB_URL=postgresql://anonymous@0.0.0.0:50827/uta/uta_20170629" \
+       -v /var/run/docker.sock:/var/run/docker.sock \
        -v  path_to_resource_files:/files/resources \
+       -v  path_to_priors_reference_files:/files/references \
        -v  path_to_output_directory:/files/data \
        -v  optional_path_to_code_base:/opt/brca-exchange \
        -v  path_to_pipeline_credentials.cfg:/opt/luigi_pipeline_credentials.cfg \

--- a/pipeline/docker/build_docker_image.sh
+++ b/pipeline/docker/build_docker_image.sh
@@ -32,6 +32,7 @@ fi
 
 # since we need this file during image building, we need to stage it into the docker context
 cp ../requirements.txt requirements_docker.txt
+cp ../../test-requirements.txt test-requirements_docker.txt
 
 DOCKER_IMAGE_NAME="brcachallenge/brca-exchange-pipeline:${DOCKER_TAG}"
 echo "Building ${DOCKER_IMAGE_NAME} with code from ${BRCA_GIT_REPO} ${COMMIT}"

--- a/pipeline/docker/run_luigi.sh
+++ b/pipeline/docker/run_luigi.sh
@@ -10,6 +10,7 @@ fi
 OUTPUT_DIR=/files/data/output
 PARENT_DIR=/files/data
 BRCA_RESOURCES=/files/resources
+PRIORS_REFERENCES=/files/references
 
 PREVIOUS_RELEASE_TAR=/files/previous_release.tar.gz
 
@@ -25,4 +26,4 @@ echo "Git hash: $(git log | head -n 1)"
 
 cd /opt/brca-exchange/pipeline/luigi
 
-python -m luigi --logging-conf-file luigi_log_configuration.conf --module CompileVCFFiles RunAll --resources-dir ${BRCA_RESOURCES} --file-parent-dir ${PARENT_DIR} --output-dir ${OUTPUT_DIR} --previous-release-tar ${PREVIOUS_RELEASE_TAR} --release-notes ${RELEASE_NOTES} ${DATE_PARAM_OPT} --local-scheduler
+python -m luigi --logging-conf-file luigi_log_configuration.conf --module CompileVCFFiles RunAll --resources-dir ${BRCA_RESOURCES} --file-parent-dir ${PARENT_DIR} --output-dir ${OUTPUT_DIR} --previous-release-tar ${PREVIOUS_RELEASE_TAR} --priors-references-dir ${PRIORS_REFERENCES} --release-notes ${RELEASE_NOTES} ${DATE_PARAM_OPT} --local-scheduler

--- a/pipeline/luigi/CompileVCFFiles.py
+++ b/pipeline/luigi/CompileVCFFiles.py
@@ -1649,8 +1649,6 @@ class RunAll(luigi.WrapperTask):
     resources_dir = luigi.Parameter(default=DEFAULT_BRCA_RESOURCES_DIR,
                                     description='directory to store brca-resources data')
 
-    priors_references_dir = luigi.Parameter(default=DEFAULT_PRIORS_REFERENCES_DIR,
-                                    description='directory to store priors references data')
 
     output_dir = luigi.Parameter(default=DEFAULT_OUTPUT_DIR,
                                  description='directory to store output files')
@@ -1660,6 +1658,9 @@ class RunAll(luigi.WrapperTask):
 
     previous_release_tar = luigi.Parameter(default=None, description='path to previous release tar for diffing versions \
                                        and producing change types for variants')
+
+    priors_references_dir = luigi.Parameter(default=DEFAULT_PRIORS_REFERENCES_DIR,
+                                    description='directory to store priors references data')
 
     release_notes = luigi.Parameter(default=None, description='notes for release, must be a .txt file')
 
@@ -1671,10 +1672,11 @@ class RunAll(luigi.WrapperTask):
         if self.release_notes and self.previous_release_tar:
             yield GenerateReleaseArchive(self.date, self.resources_dir, self.output_dir,
                                          self.file_parent_dir, self.previous_release_tar,
-                                         self.release_notes, self.priors_references_dir)
+                                         self.priors_references_dir, self.release_notes)
         elif self.previous_release_tar:
-            yield RunDiffAndAppendChangeTypesToOutputReports(self.date, self.resources_dir, self.output_dir,
-                                                      self.file_parent_dir, self.priors_references_dir, self.previous_release_tar)
+            yield RunDiffAndAppendChangeTypesToOutputReports(self.date, self.resources_dir,
+                                                             self.output_dir, self.file_parent_dir,
+                                                             self.previous_release_tar, self.priors_references_dir)
         else:
             yield BuildAggregatedOutput(self.date, self.resources_dir, self.output_dir, self.file_parent_dir)
 

--- a/pipeline/luigi/CompileVCFFiles.py
+++ b/pipeline/luigi/CompileVCFFiles.py
@@ -1309,10 +1309,10 @@ class MergeVCFsIntoTSVFile(luigi.Task):
     priors_references_dir = luigi.Parameter(default=None, description='directory to store priors references data.')
 
     priors_docker_image_name = luigi.Parameter(default=None, description='docker image name for priors calculation')
-    
+
     release_notes = luigi.Parameter(default=None, description='notes for release, must be a .txt file')
 
-    
+
     def output(self):
         artifacts_dir = create_path_if_nonexistent(self.output_dir + "/release/artifacts/")
         return luigi.LocalTarget(artifacts_dir + "merged.tsv")
@@ -1448,7 +1448,7 @@ class CalculatePriors(luigi.Task):
 
         args = ['bash', 'calcpriors.sh', self.priors_references_dir,
                 artifacts_dir_host, 'built_with_mupit.tsv', 'built_with_priors.tsv', self.priors_docker_image_name]
-        
+
         print "Running calcpriors.sh with the following args: %s" % (args)
         sp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print_subprocess_output_and_error(sp)
@@ -1467,7 +1467,7 @@ class FindMissingReports(luigi.Task):
         artifacts_dir = self.output_dir + "/release/artifacts/"
         os.chdir(data_merging_method_dir)
 
-        args = ["python", "check_for_missing_reports.py", "-b", artifacts_dir + "built_with_mupit.tsv", "-r", artifacts_dir,
+        args = ["python", "check_for_missing_reports.py", "-b", artifacts_dir + "built_with_priors.tsv", "-r", artifacts_dir,
                 "-a", artifacts_dir, "-v"]
         print "Running check_for_missing_reports.py with the following args: %s" % (args)
         sp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -1507,7 +1507,7 @@ class RunDiffAndAppendChangeTypesToOutput(luigi.Task):
         previous_release_date = self._extract_release_date(version_json_path)
         previous_release_date_str = datetime.datetime.strftime(previous_release_date, '%m-%d-%Y')
 
-        args = ["python", "releaseDiff.py", "--v2", artifacts_dir + "built_with_mupit.tsv", "--v1", previous_data_path,
+        args = ["python", "releaseDiff.py", "--v2", artifacts_dir + "built_with_priors.tsv", "--v1", previous_data_path,
                 "--removed", diff_dir + "removed.tsv", "--added", diff_dir + "added.tsv", "--added_data",
                 diff_dir + "added_data.tsv", "--diff", diff_dir + "diff.txt", "--diff_json", diff_dir + "diff.json",
                 "--output", release_dir + "built_with_change_types.tsv", "--artifacts_dir", artifacts_dir,
@@ -1519,7 +1519,7 @@ class RunDiffAndAppendChangeTypesToOutput(luigi.Task):
 
         shutil.rmtree(tmp_dir) # cleaning up
 
-        check_input_and_output_tsvs_for_same_number_variants(artifacts_dir + "built_with_mupit.tsv",
+        check_input_and_output_tsvs_for_same_number_variants(artifacts_dir + "built_with_priors.tsv",
                                                              release_dir + "built_with_change_types.tsv")
 
 
@@ -1659,7 +1659,7 @@ class RunAll(luigi.WrapperTask):
 
     output_dir = luigi.Parameter(default=DEFAULT_OUTPUT_DIR,
                                  description='directory to store output files')
-    
+
     output_dir_host = luigi.Parameter(default=DEFAULT_OUTPUT_DIR,
                                  description='directory to store output files wrt to host file system (needed for setting up volume mapping for running docker inside docker)')
 
@@ -1672,7 +1672,7 @@ class RunAll(luigi.WrapperTask):
     priors_references_dir = luigi.Parameter(default=None, description='directory to store priors references data')
 
     priors_docker_image_name = luigi.Parameter(default=None, description='docker image name for priors calculation')
-    
+
     release_notes = luigi.Parameter(default=None, description='notes for release, must be a .txt file')
 
     def requires(self):

--- a/pipeline/luigi/CompileVCFFiles.py
+++ b/pipeline/luigi/CompileVCFFiles.py
@@ -124,7 +124,6 @@ def extract_file(archive_path, tmp_dir, file_path):
 
 
 DEFAULT_BRCA_RESOURCES_DIR = (os.path.abspath('../brca/brca-resources'))
-DEFAULT_PRIORS_REFERENCES_DIR = (os.path.abspath('../brca/priors-references'))
 DEFAULT_OUTPUT_DIR = (os.path.abspath('../brca/pipeline-data/data/pipeline_input'))
 DEFAULT_FILE_PARENT_DIR = (os.path.abspath('../brca/pipeline-data/data'))
 
@@ -1659,8 +1658,7 @@ class RunAll(luigi.WrapperTask):
     previous_release_tar = luigi.Parameter(default=None, description='path to previous release tar for diffing versions \
                                        and producing change types for variants')
 
-    priors_references_dir = luigi.Parameter(default=DEFAULT_PRIORS_REFERENCES_DIR,
-                                    description='directory to store priors references data')
+    priors_references_dir = luigi.Parameter(default=None, description='directory to store priors references data')
 
     release_notes = luigi.Parameter(default=None, description='notes for release, must be a .txt file')
 
@@ -1669,11 +1667,11 @@ class RunAll(luigi.WrapperTask):
         If release notes and a previous release are provided, generate a version.json file and
         run the releaseDiff.py script to generate change_types between releases of variants.
         '''
-        if self.release_notes and self.previous_release_tar:
+        if self.release_notes and self.previous_release_tar and self.priors_references_dir:
             yield GenerateReleaseArchive(self.date, self.resources_dir, self.output_dir,
                                          self.file_parent_dir, self.previous_release_tar,
                                          self.priors_references_dir, self.release_notes)
-        elif self.previous_release_tar:
+        elif self.previous_release_tar and self.priors_references_dir:
             yield RunDiffAndAppendChangeTypesToOutputReports(self.date, self.resources_dir,
                                                              self.output_dir, self.file_parent_dir,
                                                              self.previous_release_tar, self.priors_references_dir)

--- a/pipeline/luigi/CompileVCFFiles.py
+++ b/pipeline/luigi/CompileVCFFiles.py
@@ -1448,7 +1448,7 @@ class CalculatePriors(luigi.Task):
         check_input_and_output_tsvs_for_same_number_variants(self.input().path,
                                                              self.output().path)
 
-@requires(AppendMupitStructure)
+@requires(CalculatePriors)
 class FindMissingReports(luigi.Task):
     def output(self):
         artifacts_dir = self.output_dir + "/release/artifacts/"

--- a/pipeline/luigi/CompileVCFFiles.py
+++ b/pipeline/luigi/CompileVCFFiles.py
@@ -1441,7 +1441,7 @@ class CalculatePriors(luigi.Task):
         os.chdir(priors_method_dir)
 
         args = ['./calcpriors.sh', self.priors_references_dir, self.artifacts_dir,
-            self.input().path, self.output().path]
+            'built_with_mupit.tsv', 'built_with_priors.tsv']
         print "Running calcpriors.sh with the following args: %s" % (args)
         sp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print_subprocess_output_and_error(sp)

--- a/pipeline/splicing/calcpriors.sh
+++ b/pipeline/splicing/calcpriors.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+set -o nounset
+set -o errexit
 
-INPUT_OUTPUT_DIR=$1
-REFERENCES_DIR=$2
+REFERENCES_DIR=$1
+INPUT_OUTPUT_DIR=$2
 INPUT_FILE=$3
 OUTPUT_FILE=$4
 

--- a/pipeline/splicing/calcpriors.sh
+++ b/pipeline/splicing/calcpriors.sh
@@ -30,6 +30,6 @@ docker run --rm -it \
     --user=`id -u`:`id -g` \
     -v ${REFERENCES_DIR}:/references:ro \
     -v ${INPUT_OUTPUT_DIR}:/data \
-    brcachallenge/splicing-pipeline calc ${INPUT_FILE} ${OUTPUT_FILE}
+    brcachallenge/splicing-pipeline calc /data/${INPUT_FILE} /data/${OUTPUT_FILE}
 echo "Prior calculation complete!"
 

--- a/pipeline/splicing/calcpriors.sh
+++ b/pipeline/splicing/calcpriors.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+INPUT_OUTPUT_DIR=$1
+REFERENCES_DIR=$2
+INPUT_FILE=$3
+OUTPUT_FILE=$4
+
+# Download and verify references - to be called from within the docker
+echo "Downloading references. If not already present, this may take 1-2 hours..."
+docker run -it --rm \
+    --user=`id -u`:`id -g` \
+    -v ${REFERENCES_DIR}:/references \
+    brcachallenge/splicing-pipeline references
+echo "Reference download and installation complete."
+
+# Run short test to ensure proper setup
+echo "Running short test to ensure proper set up."
+# TODO: exit if tests error
+docker run -it --rm \
+    --user=`id -u`:`id -g` \
+    -v ${REFERENCES_DIR}:/references:ro \
+    brcachallenge/splicing-pipeline test short
+echo "Tests passed!"
+
+# Calculate priors
+echo "Calculating priors, this may take a few hours..."
+docker run --rm -it \
+    --user=`id -u`:`id -g` \
+    -v ${REFERENCES_DIR}:/references:ro \
+    -v ${INPUT_OUTPUT_DIR}:/data \
+    brcachallenge/splicing-pipeline calc ${INPUT_FILE} ${OUTPUT_FILE}
+echo "Prior calculation complete!"
+


### PR DESCRIPTION
The purpose of this PR is to integrate the dockerized priors pipeline into the automated luigi pipeline.

I'm posting this PR even though there are still some outstanding issues as a request for help in getting this finished ASAP (e.g. luigi is currently complaining about an extra argument when it's called, some docker run scripts need updating, etc.):

```
pipeline@brca-pipeline:~/zfisch$ docker run --rm -u $(id -u ${USER}):$(id -g ${USER})        --network host        -e  "UTA_DB_URL=postgresql://anonymous@0.0.0.0:50827/uta/u$
a_20170629"        -v /var/run/docker.sock:/var/run/docker.sock      -v  /home/pipeline/zfisch/resources:/files/resources        -v  /home/pipeline/priors/references:/files/$
eferences      -v  /home/pipeline/zfisch/data/priors_out/brca_out:/files/data        -v  /home/pipeline/zfisch/brca-exchange:/opt/brca-exchange        -v  /home/pipeline/zfi$
ch/luigi_pipeline_credentials.cfg:/opt/luigi_pipeline_credentials.cfg        -v  /home/pipeline/monthly_releases/data_release_2018-07-21/brca_out/release-07-21-18.tar.gz:/fi$
es/previous_release.tar.gz        -v  /home/pipeline/monthly_releases/release_notes/release_notes_data_release_2018-07-21:/files/release_notes.txt        -v  /tmp:/.synapseC$
che        -it        brcachallenge/brca-exchange-pipeline:priors
WARNING: BRCA Code base mounted from host file system
Running brca exchange pipeline:
Git hash: commit 53e5bb2416570b154d704900c1b684a1645b7a40
2018-08-29 04:24:54,007 worker.py       Checking if RunAll(date=2018-08-29, u=_____, synapse_username=______, synapse_enigma_file_id=_______, resources_dir=/files/reso$rces, output_dir=/files/data/output, file_parent_dir=/files/data, previous_release_tar=/files/previous_release.tar.gz, priors_references_dir=/files/references, release_notes$/files/release_notes.txt) is complete
2018-08-29 04:24:54,016 worker.py       Will not run RunAll(date=2018-08-29, u=______, synapse_username=______, synapse_enigma_file_id=______, resources_dir=/files/res$urces, output_dir=/files/data/output, file_parent_dir=/files/data, previous_release_tar=/files/previous_release.tar.gz, priors_references_dir=/files/references, release_note$=/files/release_notes.txt) or any dependencies due to error in complete() method:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 290, in check_complete
    is_complete = task.complete()
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 562, in complete
    return all(r.complete() for r in flatten(self.requires()))
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 626, in flatten
    for result in iterator:
  File "CompileVCFFiles.py", line 1675, in requires
    self.priors_references_dir, self.release_notes)
  File "/usr/local/lib/python2.7/dist-packages/luigi/task_register.py", line 91, in __call__
    param_values = cls.get_param_values(params, args, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 249, in get_param_values
    raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))
UnknownParameterException: GenerateReleaseArchive[args=(datetime.date(2018, 8, 29), '/files/resources', '/files/data/output', '/files/data', '/files/previous_release.tar.gz'$ '/files/references', '/files/release_notes.txt'), kwargs={}]: takes at most 6 parameters (7 given)
```

I'll resume debugging and further development tomorrow, @izcram please let me know if you're able to identify any issues before then.

Thanks!