### PR TITLE
few fixes running the splicing docker

### DIFF
--- a/pipeline/docker/run_luigi.sh
+++ b/pipeline/docker/run_luigi.sh
@@ -10,7 +10,7 @@ fi
 OUTPUT_DIR=/files/data/output
 PARENT_DIR=/files/data
 BRCA_RESOURCES=/files/resources
-PRIORS_REFERENCES=/files/references
+PRIORS_REFERENCES=/home/pipeline/priors/references # path valid w.r.t to host (needed inside splicing prior pipeline) TODO make a parameter out of it
 
 PREVIOUS_RELEASE_TAR=/files/previous_release.tar.gz
 


### PR DESCRIPTION
the fixes which seem to fix the some integration issues (partially).

I've kicked it off using (not sure privileged flag)

```
WDIR=/home/pipeline/marc_dev                                   

# for access to /var/run/docker.sock
DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)                

docker run -it --privileged --rm -u $(id -u ${USER}):${DOCKER_GID} --network host \                                            
       -e  "UTA_DB_URL=postgresql://anonymous@0.0.0.0:50827/uta/uta_20170629" \                                                
       -v /var/run/docker.sock:/var/run/docker.sock \          
       -v ${WDIR}/resources:/files/resources \                 
       -v /home/pipeline/priors/references:/files/references \ 
       -v ${WDIR}/brca_out_integrated_dirty:/files/data \      
       -v ${WDIR}/brca-exchange:/opt/brca-exchange \           
       -v /home/pipeline/monthly_releases/scripts/luigi_pipeline_credentials.cfg:/opt/luigi_pipeline_credentials.cfg \         
       -v /home/pipeline/monthly_releases/data_release_2018-07-21/brca_out/release-07-21-18.tar.gz:/files/previous_release.tar.gz \                                                                                                                    
       -v  /home/pipeline/monthly_releases/release_notes/release_notes_data_release_2018-07-21:/files/release_notes.txt \      
       -v  /tmp:/.synapseCache \                               
       -it brcachallenge/brca-exchange-pipeline:priors /opt/brca-exchange/pipeline/docker/run_luigi.sh              
```