### PR TITLE
Add clin var list fields to diff

### DIFF
--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -52,6 +52,8 @@ LIST_KEYS = [
             "SCV_ClinVar",
             "Clinical_Significance_ClinVar",
             "Allele_Origin_ClinVar",
+            "DateSignificanceLastEvaluated_ClinVar",
+            "SCV_Verson_ClinVar",
             "Synonyms",
             "Submitters_LOVD",
             "RNA_LOVD",

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -59,6 +59,8 @@ LIST_KEYS = [
             "RNA_LOVD",
             "Variant_effect_LOVD",
             "Genetic_origin_LOVD",
+            "Created_date_LOVD",
+            "Edited_date_LOVD",
             "DBID_LOVD",
             "HGVS_cDNA_LOVD",
             "BX_ID_ENIGMA",

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -44,17 +44,17 @@ PYHGVS_GENOMIC_COORDINATE_FIELDS = ["pyhgvs_Genomic_Coordinate_38",
 
 LIST_KEYS = [
             "Pathogenicity_all",
+            "Source",
+            "Source_URL",
+            "Synonyms",
             "Submitter_ClinVar",
             "Method_ClinVar",
-            "Source",
             "Date_Last_Updated_ClinVar",
-            "Source_URL",
             "SCV_ClinVar",
             "Clinical_Significance_ClinVar",
             "Allele_Origin_ClinVar",
             "DateSignificanceLastEvaluated_ClinVar",
             "SCV_Verson_ClinVar",
-            "Synonyms",
             "Submitters_LOVD",
             "RNA_LOVD",
             "Variant_effect_LOVD",
@@ -70,7 +70,6 @@ LIST_KEYS = [
             "BX_ID_1000_Genomes",
             "BX_ID_ESP"
            ]
-
 
 EXAC_AF_FIELDS = [
     "Allele_frequency_ExAC",


### PR DESCRIPTION
Properly handles additional list keys during diff. It would be best to rerun diff and post-diff portion of the pipeline after merging this code to generate a cleaner release.
