### PR TITLE
Replaces muts-needle-plot with a version that builds with nodejs > 6.9.0.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "markdown-it-loader": "^0.1.0",
     "mocha": "^2.2.1",
     "mocha-loader": "^0.7.1",
-    "muts-needle-plot": "git+https://github.com/cmarkello/muts-needle-plot.git#polish_sandbox",
+    "muts-needle-plot": "git+https://github.com/BRCAChallenge/muts-needle-plot.git#polish_sandbox",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.3.2",
     "semver": "^5.3.0",


### PR DESCRIPTION
Addresses issue #899. Specifically, this PR swaps out the dependency on cmarkello's muts-needle-plot for BRCAChallenge's fork, which includes a few commits to upgrade/remove libraries that were incompatible with nodejs versions > 6.9.0.

I haven't done any formal testing, but I ran the site with the replaced dependency locally and tried out the lollipop charts. I didn't see anything obviously broken with it, but it'd be nice to have a second opinion.

Original repo: https://github.com/cmarkello/muts-needle-plot/tree/polish_sandbox
Revised repo: https://github.com/BRCAChallenge/muts-needle-plot/tree/polish_sandbox