### PR TITLE
remove url decode from lovd reports aggregation, add test

### DIFF
--- a/pipeline/data_merging/aggregate_reports.py
+++ b/pipeline/data_merging/aggregate_reports.py
@@ -4,7 +4,6 @@ import os
 import vcf
 import logging
 import csv
-import urllib
 from variant_merging import (
      add_columns_to_enigma_data,
      associate_chr_pos_ref_alt_with_enigma_item,
@@ -113,10 +112,7 @@ def normalize_vcf_reports(file, columns, filename, file_extension):
             try:
                 column_name = key + "_" + source
                 column_index = columns.index(column_name)
-                if source == "LOVD":
-                    report[column_index] = map(urllib.unquote_plus, record.INFO[value])
-                else:
-                    report[column_index] = record.INFO[value]
+                report[column_index] = record.INFO[value]
             except KeyError:
                 raise Exception("WARNING: Key error with report: %s \n\nError on value: %s \n\n Error in record.INFO: %s \n\nNeeds attn." % (report, value, record.INFO))
         reports.append(report)

--- a/pipeline/data_merging/test_aggregate_reports.py
+++ b/pipeline/data_merging/test_aggregate_reports.py
@@ -5,7 +5,6 @@ import csv
 from os import path, getcwd
 import aggregate_reports
 
-
 VCF_TESTDATA_FILENAME = path.join(path.dirname(__file__), 'test_files/1000_Genomes.vcf')
 TSV_TESTDATA_FILENAME = path.join(path.dirname(__file__), 'test_files/enigma_from_clinvar.tsv')
 INPUT_DIRECTORY = path.join(path.dirname(__file__), 'test_files/')
@@ -123,6 +122,17 @@ class TestStringMethods(unittest.TestCase):
                 source_reports[source] += 1
         for source in self.sources:
             self.assertEqual(source_reports[source], 2)
+
+    def test_aggregate_reports_maintains_proper_variant_effect_lovd_formatting(self):
+        LOVD_reports_file = [INPUT_DIRECTORY + r for r in aggregate_reports.get_reports_files(INPUT_DIRECTORY) if r == 'LOVD.vcf']
+        reports = aggregate_reports.aggregate_reports(LOVD_reports_file, self.columns)
+
+        # Check that two of each source are present
+        variant_effect_lovd_index = self.columns.index("Variant_effect_LOVD")
+
+        for variant in reports:
+            self.assertIn(variant[variant_effect_lovd_index][0], ['?/.', '+/+'])
+
 
 
 if __name__ == '__main__':

--- a/pipeline/data_merging/test_files/LOVD.vcf
+++ b/pipeline/data_merging/test_files/LOVD.vcf
@@ -1,10 +1,10 @@
 ##fileformat=VCFv4.0
-##source=exLOVD
+##source=LOVD
 ##reference=GRCh37
 ##liftOverProgram=CrossMap(https://sourceforge.net/projects/crossmap/)
 ##liftOverFile=/files/resources/hg19ToHg38.over.chain.gz
 ##new_reference_genome=/files/resources/hg38.fa
-##liftOverTime=May08,2018
+##liftOverTime=November03,2018
 ##INFO=<ID=dbsnp_id,Number=.,Type=String,Description="The dbSNP ID.">
 ##INFO=<ID=db_id,Number=.,Type=String,Description="Database ID of variant, grouping multiple observations of the same variant together, starting with the HGNC gene symbol, followed by an underscore (_) and a six digit number (e.g. DMD_012345). _000000 is used for variants where DNA was not analysed (change predicted from RNA analysis), variants seen in animal models or variants not seen in humans but functionally tested in vitro.">
 ##INFO=<ID=reference,Number=.,Type=String,Description="publication describing the variant submitted, incl. links to OMIM, PubMed or other source, e.g. den Dunnen ASHG2003 P2346.">
@@ -27,5 +27,5 @@
 ##INFO=<ID=variant_remarks,Number=.,Type=String,Description="Remarks regarding variant described, e.g. germline mosaicism in mother, 345 kb deletion, muscle RNA analysed, not in 200 control chromosomes tested, on founder haplotype, etc.">
 ##INFO=<ID=published_as,Number=.,Type=String,Description="Listed only when different from DNA change; variant as reported originally (e.g. 521delT). Variants seen in animal models, tested in vitro, predicted from RNA analysis, etc. are described between brackets like c.(456C>G)">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-13	32349814	NM_000059.3:c.7007+2936del	CA	C	.	.	genetic_origin=SUMMARY+record;frequency=;BX_ID=6110;DBID=BRCA2_005091;Protein=p.%28%3D%29;RNA=r.%28%3F%29;cDNA=NM_000059.3%3Ac.7007%2B2936del;chromosome=chr13;created_date=2016-09-28 12:00:00;edited_date=2018-03-30 16:37:02;gDNA=g.32923969del;geneid=BRCA2;functional_analysis=;functional_analysis_technique=;functional_analysis_result=;individuals=1;submission_id=NM_000059.3:c.7007+2936delENIGMA consortium (Brisbane,AU);submitters=ENIGMA+consortium+%28Brisbane%2CAU%29;variant_effect=-%2F-
-17	43092719	NM_007294.3:c.2812C>T	G	A	.	.	genetic_origin=Unknown;frequency=;BX_ID=13673;DBID=BRCA1_001422;Protein=p.%28Pro938Ser%29;RNA=r.%28%3F%29;cDNA=NM_007294.3%3Ac.2812C%3ET;chromosome=chr17;created_date=2014-02-03 11:09:45;edited_date=2016-08-05 14:13:49;gDNA=g.41244736G>A;geneid=BRCA1;functional_analysis=;functional_analysis_technique=;functional_analysis_result=;individuals=1;submission_id=NM_007294.3:c.2812C>THans Gille (Amsterdam,NL);submitters=Hans+Gille+%28Amsterdam%2CNL%29;variant_effect=%3F%2F%3F
+13	32314514	NM_000059.3:c.-1193C>T	C	T	.	.	genetic_origin=Germline;frequency=1/6603 cases;BX_ID=1;DBID=BRCA2_006612;Protein=p.(=);RNA=r.(=);cDNA=NM_000059.3:c.-1193C>T;chromosome=chr13;created_date=2018-10-08 06:45:24;edited_date=2018-10-08 06:45:24;functional_analysis=;functional_analysis_result=;functional_analysis_technique=;gDNA=g.32888651C>T;geneid=BRCA2;individuals=1;submission_id=NM_000059.3:c.-1193C>TLez J Burke (Brisbane,AU);submitters=Lez J Burke (Brisbane,AU);variant_effect=?/.
+13	32314585	NM_000059.3:c.-1122T>C	T	C	.	.	genetic_origin=Germline;frequency=1/6603 cases;BX_ID=2;DBID=BRCA2_006613;Protein=p.(=);RNA=r.(=);cDNA=NM_000059.3:c.-1122T>C;chromosome=chr13;created_date=2018-10-08 06:45:24;edited_date=2018-10-08 06:45:24;functional_analysis=;functional_analysis_result=;functional_analysis_technique=;gDNA=g.32888722T>C;geneid=BRCA2;individuals=1;submission_id=NM_000059.3:c.-1122T>CLez J Burke (Brisbane,AU);submitters=Lez J Burke (Brisbane,AU);variant_effect=+/+


### PR DESCRIPTION
Fixes issue where variant effects are improperly decoded during reports aggregation -- leads to missing results in the LOVD tile.