### PR TITLE
Left-justifies allele frequency, LOVD report subtile headers

### DIFF
--- a/website/js/components/SourceReportsTile.js
+++ b/website/js/components/SourceReportsTile.js
@@ -5,6 +5,7 @@
 import React from "react";
 import {Panel} from 'react-bootstrap';
 import util from '../util';
+import slugify from '../slugify';
 import {VariantSubmitter} from "./VariantSubmitter";
 
 import GroupHelpButton from './GroupHelpButton';
@@ -160,7 +161,7 @@ export default class SourceReportsTile extends React.Component {
         );
 
         return (
-            <div key={`group_collection-${groupTitle}`} className="variant-detail-group variant-submitter-group">
+            <div key={`group_collection-${groupTitle}`} className={`variant-detail-group variant-submitter-group ${slugify(this.props.sourceName)}-submitter`}>
                 <Panel
                     ref={(me) => { this.collapser = me; }}
                     header={header}

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -1175,6 +1175,11 @@ div.variant-submitter-group .submitter-header td {
     flex: 0 0 203px; /* the +3 gets it to line up with the columns below it */
 }
 
+.lovd-submitter .submitter-header .submitter-cell.submitter-label {
+    text-align: left;
+    flex: none;
+}
+
 .allele-frequency-header td {
     border-bottom-width: 3px;
 }

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -1203,8 +1203,9 @@ div.variant-submitter-group .submitter-header td {
 .allele-frequency-header .allele-frequency-cell.allele-frequency-label {
     font-weight: bold;
     white-space: nowrap;
-    text-align: right;
-    flex: 0 0 203px; /* the +3 gets it to line up with the columns below it */
+    /*text-align: right;*/
+    /*flex: 0 0 203px;*/
+    /* the +3 gets it to line up with the columns below it */
 }
 
 .submitter-header .submitter-cell.submitter-name {


### PR DESCRIPTION
The allele frequency and LOVD report subtile headers are now left-aligned (instead of aligned with the other within-tile fields) and take up the full horizontal space within their tile. ClinVar reports are unchanged. Fixes #971.

Examples:
![screenshot 2019-01-21 at 11 51 47](https://user-images.githubusercontent.com/312923/51470021-fecf8180-1d72-11e9-9dcc-a6e36b858553.png)

![screenshot 2019-01-21 at 11 52 22](https://user-images.githubusercontent.com/312923/51470035-0abb4380-1d73-11e9-9644-742de54b653b.png)

