### PR TITLE
Feature/integrating seq repo

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -13,6 +13,8 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 LUIGI_ROOT_TASK = GenerateReleaseArchive
 LUIGI_WORKERS = 8
 
+SEQ_REPO_DIR_DOCKER := /files/resources/seq_repo
+
 init: ## setup config file
 	echo "creating file in $(CONFIG_PATH). Please edit to your needs in particular the WORK_DIR!"
 	jinja2 -D DATA_DATE=2099-12-31 \
@@ -30,7 +32,6 @@ build-docker: ## build main pipeline docker image
 
 download-resources: ## download resources files
 	$(CODE_BASE)/pipeline/download_resources_files.sh $(RESOURCES_DIR) >> "$(LOG_DIR)/download_resources_$(RELEASE_TAG).log" 2>&1 || { echo "Downloading resource files failed"; exit 1; }
-
 
 start-local-uta: ## starting local uta docker container
 	[ `docker ps -f name=$(UTA_CONTAINER) | wc -l` -gt 1 ] || docker run -dit --name $(UTA_CONTAINER) -p $(UTA_PORT):5432 $(UTA_DOCKER_IMAGE)
@@ -60,7 +61,8 @@ endif
 
 COMMON_DOCKER_ARGS = --rm -u `id -u ${USER}`:$(DOCKER_GRP) \
 	-e "DATA_DATE=$(DATA_DATE)" \
-        -e"UTA_DB_URL=postgresql://anonymous@0.0.0.0:$(UTA_PORT)/uta/uta_$(UTA_RELEASE_DATE)" \
+        -e "UTA_DB_URL=postgresql://anonymous@0.0.0.0:$(UTA_PORT)/uta/uta_$(UTA_RELEASE_DATE)" \
+	-e "HGVS_SEQREPO_DIR=$(SEQ_REPO_DIR_DOCKER)/latest" \
 	--network host \
 	-v $(RESOURCES_DIR):/files/resources \
 	-v $(OUT_DIR):/files/data \
@@ -69,6 +71,9 @@ COMMON_DOCKER_ARGS = --rm -u `id -u ${USER}`:$(DOCKER_GRP) \
 	-v $(RELEASE_NOTES_PATH):/files/release_notes.txt \
 	-v $(CODE_BASE):/opt/brca-exchange \
 	-v /var/run/docker.sock:/var/run/docker.sock
+
+download-seqrepo: ## Download seq repo data
+	docker run $(COMMON_DOCKER_ARGS) $(PIPELINE_IMAGE) bash -c "mkdir -p $(SEQ_REPO_DIR_DOCKER) && seqrepo --root-directory $(SEQ_REPO_DIR_DOCKER) pull && seqrepo --root-directory $(SEQ_REPO_DIR_DOCKER) update-latest"
 
 run-pipeline: ## running entire pipeline
 	TS=`date +%Y%m%d_%H%M%S`
@@ -107,7 +112,7 @@ show-luigi-graph: ## print some representation of the luigi compute graph on the
 test: ## Running pipeline unit tests
 	docker run $(COMMON_DOCKER_ARGS) $(PIPELINE_IMAGE) bash -c 'cd /opt/brca-exchange/pipeline/data && bash getdata && cd /opt/brca-exchange/pipeline && pytest --ignore=splicing/'
 
-build-release: start-local-uta checkout build-docker setup-files setup-lovd download-resources run-pipeline variants-by-source ## create new data release
+build-release: start-local-uta checkout build-docker setup-files setup-lovd download-resources download-seqrepo run-pipeline variants-by-source ## create new data release
 
 variants-by-source: ## postprocessing: compute statistics for changes with respect to the last release
 	docker run $(COMMON_DOCKER_ARGS) $(PIPELINE_IMAGE) python /opt/brca-exchange/pipeline/utilities/variantsBySource.py  -i /files/data/output/release/built_with_change_types.tsv -c true

--- a/pipeline/clinvar/enigma_from_clinvar.py
+++ b/pipeline/clinvar/enigma_from_clinvar.py
@@ -1,8 +1,6 @@
 import copy
 import itertools
-import multiprocessing
 import re
-from multiprocessing.pool import ThreadPool
 
 import click
 import pandas as pd
@@ -289,11 +287,7 @@ def main(filtered_clinvar_xml, output):
 
     hgvs_util = hgvs_utils.HGVSWrapper()
 
-    pool = ThreadPool(1) #multiprocessing.cpu_count()) # just using one thread as we are running issues with hgvs_utils in a parallel setting
-
-    # parallelizing, as computing protein changes takes a while due to external API calls
-    variant_records_lsts = pool.map(lambda s: parse_record(s, hgvs_util),
-                               enigma_sets)
+    variant_records_lsts = [ parse_record(s, hgvs_util) for s in enigma_sets ]   
 
     # flattening list of lists
     variant_records = list(itertools.chain.from_iterable(variant_records_lsts))

--- a/pipeline/clinvar/hgvs_utils.py
+++ b/pipeline/clinvar/hgvs_utils.py
@@ -4,7 +4,7 @@ import hgvs.dataproviders.uta
 import hgvs.assemblymapper
 
 import logging
-
+import time
 
 # TODO: does not belong here. move to utilties or similar. but then need to change how luigi stuff is ran.
 class HGVSWrapper:
@@ -14,16 +14,30 @@ class HGVSWrapper:
         self.hgvs_hp = hgvs.parser.Parser()
         self.hgvs_am = hgvs.assemblymapper.AssemblyMapper(self.hgvs_dp)
 
-
+        
     # TODO: think about interface
-    def compute_protein_change(self, hgvs_cnda, include_braces=True):
+    
+    def compute_protein_change(self, hgvs_cdna, include_braces=True, retry_cnts = 5):
+        
         try:
-            v = self.hgvs_hp.parse_hgvs_variant(hgvs_cnda)
+            v = self.hgvs_hp.parse_hgvs_variant(hgvs_cdna)
             vp = self.hgvs_am.c_to_p(v)
 
             if include_braces and vp and vp.posedit:
                 vp.posedit.uncertain = True
+        except hgvs.exceptions.HGVSDataNotAvailableError as e:
+            time.sleep(1)
+            
+            if(retry_cnts > 0):
+                logging.warn("Retrying another time for %s", hgvs_cdna)
+                
+                return self.compute_protein_change(hgvs_cdna, include_braces, retry_cnts - 1)
+            else:
+                # fail the pipeline. We actually should get data, but don't due to some intermittent issue
+                # see also https://github.com/biocommons/hgvs/issues/519
+                raise RuntimeError("HGVS data not available for %s . Cannot continue. Error was %s", hgvs_cdna, e.message)
         except Exception as e:
-            logging.warning('Issues converting %s. %s', hgvs_cnda, e.message)
+            logging.warning('Issues converting %s. %s type %s', hgvs_cdna, e.message, type(e))
             return None
+
         return vp

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,6 +1,6 @@
 backports-abc==0.4
 beautifulsoup4==4.5.1
-biocommons.seqrepo==0.3.5
+biocommons.seqrepo==0.4.4
 biopython==1.69
 bioutils==0.3.3
 bx-python==0.7.3
@@ -9,7 +9,7 @@ configparser==3.5.0
 CrossMap==0.2.6
 Cython==0.24.1
 docutils==0.12
-hgvs==1.1.2
+hgvs==1.2.4
 itertoolz==0.5
 lxml==4.2.5
 lockfile==0.12.2

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,6 +1,6 @@
 backports-abc==0.4
 beautifulsoup4==4.5.1
-biocommons.seqrepo==0.4.4
+git+https://github.com/biocommons/biocommons.seqrepo.git@129d285727228920dd2d7746a47c48eb7b88b191 # fixing issue with seqrepo update-latest command. TODO change to release > 0.4.4 as soon as it is available
 biopython==1.69
 bioutils==0.3.3
 bx-python==0.7.3


### PR DESCRIPTION
Solves #917
Code to set up local biocommons seqrepo (an additional few GB to download...).
This helps us circumvent issues with NCBI API throttling us and leading to randomly missing protein data for enigma data.
Updating biocommons packages to the most recent versions (hgvs and seqrepo).
Removing parallelisation in enigma_via_clinvar.py since it is reasonably fast now with the local seqrepo. Also multithreading seems to cause issues with using the local seqrepo, could perhaps be addressed in the future

