### PR TITLE
Fixes lit. search results stretching the page horizontally

### DIFF
--- a/website/js/components/LiteratureTable.js
+++ b/website/js/components/LiteratureTable.js
@@ -210,7 +210,7 @@ class LiteratureTable extends React.Component {
 
                         <AuthorList authors={authors} maxCount={3} />
 
-                        <div style={{marginTop: '10px'}}>
+                        <div className="lit-text-matches">
                             <b>Text Matches:</b>
                             {
                                 mentions.length ? (

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -1415,3 +1415,12 @@ tr.highlighted td:last-child { border-right: solid 2px red; font-weight: bold; }
     padding: 2px 4px;
     max-width: 60%;
 }
+
+.variant-literature-col .lit-text-matches {
+    margin-top: 1em;
+}
+
+.variant-literature-col .lit-text-matches ol li {
+    word-break: break-word;
+    overflow-wrap: break-word
+}


### PR DESCRIPTION
Force-breaks long lines in the literature search text matches, allowing the page to correctly scale to the viewport. Fixes #996.