### PR TITLE
Printable "Variant Details" Page

### DIFF
--- a/website/js/components/AlleleFrequenciesTile.js
+++ b/website/js/components/AlleleFrequenciesTile.js
@@ -111,12 +111,14 @@ export default class AlleleFrequenciesTile extends React.Component {
                 </a>
 
                 <a title='collapse all fields'
+                   className="toggle-subfields"
                     onClick={(event) => this.setAllFieldsExpansion(event, false)}
                     style={{cursor: 'pointer', marginRight: '10px'}}>
                     <i className="fa fa-angle-double-up" aria-hidden="true" />
                 </a>
 
                 <a title='expand all fields'
+                   className="toggle-subfields"
                     onClick={(event) => this.setAllFieldsExpansion(event, true)}
                     style={{cursor: 'pointer'}}>
                     <i className="fa fa-angle-double-down" aria-hidden="true" />

--- a/website/js/components/SourceReportsTile.js
+++ b/website/js/components/SourceReportsTile.js
@@ -137,12 +137,14 @@ export default class SourceReportsTile extends React.Component {
                 </a>
 
                 <a title='collapse all reports'
+                   className="toggle-subfields"
                     onClick={(event) => this.setAllReportExpansion(event, false)}
                     style={{cursor: 'pointer', marginRight: '10px'}}>
                     <i className="fa fa-angle-double-up" aria-hidden="true" />
                 </a>
 
                 <a title='expand all reports'
+                   className="toggle-subfields"
                     onClick={(event) => this.setAllReportExpansion(event, true)}
                     style={{cursor: 'pointer'}}>
                     <i className="fa fa-angle-double-down" aria-hidden="true" />

--- a/website/js/components/collapsible/CollapsibleTile.js
+++ b/website/js/components/collapsible/CollapsibleTile.js
@@ -76,12 +76,14 @@ export default class CollapsibleTile extends React.Component {
                 </a>
 
                 <a title='collapse all fields'
+                   className="toggle-subfields"
                     onClick={(event) => this.setAllFieldsExpansion(event, false)}
                     style={{cursor: 'pointer', marginRight: '10px'}}>
                     <i className="fa fa-angle-double-up" aria-hidden="true" />
                 </a>
 
                 <a title='expand all fields'
+                   className="toggle-subfields"
                     onClick={(event) => this.setAllFieldsExpansion(event, true)}
                     style={{cursor: 'pointer'}}>
                     <i className="fa fa-angle-double-down" aria-hidden="true" />

--- a/website/js/components/insilicopred/InSilicoPredSubtile.js
+++ b/website/js/components/insilicopred/InSilicoPredSubtile.js
@@ -11,7 +11,7 @@ class PathosProbScale extends React.Component {
         const {value, brackets} = this.props;
 
         return (
-            <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100" viewBox="0 0 500 60">
+            <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="auto" viewBox="0 0 500 70" preserveAspectRatio="xMidYMid meet">
                 <defs>
                     <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
                         <stop offset="0%"   style={{stopColor: '#0000FE', stopOpacity: 1}} />
@@ -90,7 +90,7 @@ export default class InSilicoPredSubtile extends React.Component {
 
         return (
             <div>
-                <div className="subtile-container" style={{padding: 0}}>
+                <div className="subtile-container" style={{padding: '20px 0'}}>
                     <PathosProbScale value={probability} brackets={4} />
                 </div>
 

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -1444,4 +1444,9 @@ tr.highlighted td:last-child { border-right: solid 2px red; font-weight: bold; }
     .toggle-subfields {
         display: none !important;
     }
+
+    /* disables bootstrap's "helpful" displaying of link URLs when printing */
+    a[href]:after {
+        content: none
+    }
 }

--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -1422,5 +1422,26 @@ tr.highlighted td:last-child { border-right: solid 2px red; font-weight: bold; }
 
 .variant-literature-col .lit-text-matches ol li {
     word-break: break-word;
-    overflow-wrap: break-word
+    overflow-wrap: break-word;
+}
+
+/**************************************************************/
+/**********     printing overrides        *********************/
+/**************************************************************/
+
+@media print {
+    /* sourced (with modifications) from https://stackoverflow.com/a/13955084/346905 */
+    .isogrid-item[style] {
+        position: relative !important;
+        display: block !important;
+        left: 0 !important;
+        top: auto !important;
+        float: left;
+    }
+
+    div.panel-heading .panel-help-btn,
+    .Variant-detail-headerbar button,
+    .toggle-subfields {
+        display: none !important;
+    }
 }


### PR DESCRIPTION
First pass at making the "Variant Details" page render correctly when printed. Addresses issue #990.

A PDF of the output: [BRCA Exchange Details.pdf](https://github.com/BRCAChallenge/brca-exchange/files/2907063/BRCA.Exchange.Details.pdf)

To reduce clutter, the following elements are hidden in the printout:
- the "Show/Hide Empty Fields" button in the header,
- help buttons in the tile header,
- "expand/collapse all subtiles" buttons in tiles with subtiles,
- URLs for links (Bootstrap displays them by default)

Remaining issues/questions:
- Bootstrap helpfully pushes table cells that would run over a page boundary to the next page, but it still renders an empty cell border to the bottom of the page. I'm undecided about whether that looks or not.
- The list of changes for a variant can be pretty verbose, so we might consider hiding it by default. On the other hand, it's not hard for the user to just print a subset of the pages, allowing them to exclude that data since it's all at the end of the page.