### PR TITLE
use output of required task rather than input when copying output files

### DIFF
--- a/pipeline/luigi/pipeline_common.py
+++ b/pipeline/luigi/pipeline_common.py
@@ -92,5 +92,5 @@ class CopyOutputToOutputDir(DefaultPipelineTask):
         pipeline_utils.create_path_if_nonexistent(
             os.path.dirname(self.output().path))
 
-        copy(self.req_task.input().path, self.output().path)
+        copy(self.req_task.output().path, self.output().path)
         pipeline_utils.check_file_for_contents(self.output().path)


### PR DESCRIPTION
I noticed `pipeline_common.CopyOutputToOutputDir()` was copying the wrong file -- this makes sure it copies the output of the required task rather than the input (sorted vs unsorted in the case of ESP).