### PR TITLE
update header help buttons

### DIFF
--- a/website/content/help/research/clinical-significance-lovd.md
+++ b/website/content/help/research/clinical-significance-lovd.md
@@ -64,7 +64,7 @@ According to LOVD’s homepage, the Leiden Open Variation Database seeks to “p
 * #### Variant ID (Database ID) ((report-DBID_LOVD))
 	The ID given to the variant by LOVD. This ID is variant-specific, but not submitter-specific. Please note that this is an important difference from ClinVar’s data specifications.
 
-* #### Functional Analysis/Technique  & Functional Result
+* #### Functional Analysis/Technique  & Functional Result ((functional-assay))
 	Free-text input provided by the LOVD submitter to give more detail about variant interpretations in the submission
 
 	* #### Analysis/Technique ((report-Functional_analysis_technique_LOVD))

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -122,6 +122,7 @@ const researchModeGroups = [
                 return starDiff || datetimeDiff;
             },
             submitter: {title: 'Submitter', prop: 'Submitter_ClinVar'},
+            helpKey: 'clinical-significance-clinvar',
             cols: [
                 // displayed here in full since the display in the header is potentially truncated
                 {title: 'Submitter', prop: 'Submitter_ClinVar'},
@@ -144,6 +145,7 @@ const researchModeGroups = [
     {groupTitle: 'Clinical Significance (LOVD)', internalGroupName: 'Significance (LOVD)', reportSource: 'LOVD',
         reportBinding: {
             submitter: {title: 'Submitter(s)', prop: 'Submitters_LOVD'},
+            helpKey: 'clinical-significance-lovd',
             cols: [
                 // displayed here in full since the display in the header is potentially truncated
                 {title: 'Submitter(s)', prop: 'Submitters_LOVD'},

--- a/website/js/content.js
+++ b/website/js/content.js
@@ -200,6 +200,7 @@ const helpContentResearch = [
         tiles: [
             {
                 name: "What are the fields in the Variant Nomenclature Tile?",
+                id: "variant-nomenclature",
                 contents: require("../content/help/research/variant-nomenclature.md")
             },
             {
@@ -212,10 +213,12 @@ const helpContentResearch = [
                     },
                     {
                         name: "ClinVar",
+                        id: "clinical-significance-clinvar",
                         contents: require("../content/help/research/clinical-significance-clinvar.md")
                     },
                     {
                         name: "Leiden Open Variation Database (LOVD)",
+                        id: "clinical-significance-lovd",
                         contents: require("../content/help/research/clinical-significance-lovd.md")
                     },
                     {
@@ -227,15 +230,18 @@ const helpContentResearch = [
             },
             {
                 name: "What information is displayed in the Transcript Visualization?",
+                id: "transcript-visualization",
                 contents: require("../content/help/research/transcript-visualization.md")
             },
             {
                 name: "What data is used in Multifactorial Likelihood Analysis?",
+                id: "multifactorial-likelihood-analysis",
                 contents: require("../content/help/research/multifactorial-likelihood-analysis.md"),
                 reference: "https://www.ncbi.nlm.nih.gov/pubmed/21990134"
             },
             {
                 name: "What information is provided in the Allele Frequency Reference Sets Tile?",
+                id: "allele-frequency-reference-sets",
                 contents: require("../content/help/research/allele-frequency-reference-sets.md"),
                 list: [
                     {
@@ -254,6 +260,7 @@ const helpContentResearch = [
             },
             {
                 name: "What sources are available in the Functional Assay Results tile?",
+                id: "functional-assay-results",
                 contents: require("../content/help/research/functional-assay-disclaimer.md"),
                 list: [
                     {
@@ -264,6 +271,7 @@ const helpContentResearch = [
             },
             {
                 name: "What are In Silico Prior Probabilities of Pathogenicity?",
+                id: "in-silico-prior-probabilities-of-pathogenicity",
                 contents: require("../content/help/research/insilico/insilico-pred.md")
             },
             {
@@ -278,7 +286,6 @@ const helpContentResearch = [
             },
             {
                 name: "What genome build is this site using?",
-                id: "cravat-mupit-3d-protein-view",
                 contents: require("../content/help/research/what-genome-build-is-this-site-using.md")
             },
             {

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -783,7 +783,7 @@ var VariantDetail = React.createClass({
                         onDimsChanged={(collapser) => {
                             this.relayoutOnCollapsed(collapser);
                         }}
-                        helpSection="functional-assay"
+                        helpSection="functional-assay-results"
                         showHelp={this.showHelp}
                     />
                 );

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -730,6 +730,7 @@ var VariantDetail = React.createClass({
                         onReportToggled={(collapser) => {
                             this.relayoutOnCollapsed(collapser);
                         }}
+                        helpSection={reportBinding.helpKey}
                         showHelp={this.showHelp}
                         tooltips={this.state.tooltips}
                     />


### PR DESCRIPTION
Fixes tile header help button links not linking to the help docs correctly. Adds help buttons to the report tile headers. Closes #1042.