### PR TITLE
Fixes URL redirection

### DIFF
--- a/website/js/css/custom.css
+++ b/website/js/css/custom.css
@@ -209,9 +209,18 @@ offending file, for future reference: website/node_modules/react-data-components
 /**************************************************************/
 /**********     Variant Detail            *********************/
 /**************************************************************/
+.variant-message {
+    text-align: center;
+}
 .deleted-variant-message {
     color: red;
-    text-align: center;
+}
+.outdated-variant-message {
+    color: red;
+    font-size: 18px;
+}
+.redirected-variant-msg {
+    color: #333;
 }
 
 .alleleFrequencyChart {

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -1213,7 +1213,7 @@ var VariantDetail = React.createClass({
 
                 <Row>
                     <Col md={12} className="variant-history-col">
-                        <h4>Previous Versions of this Variant:</h4>
+                        <h4>Previous Versions of this Variant (up to {util.reformatDate(data[0].Data_Release.date)}):</h4>
                         <Table className='variant-history nopointer' responsive bordered>
                             <thead>
                                 <tr className='active'>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -1121,7 +1121,7 @@ var VariantDetail = React.createClass({
                           <Col xs={12} classname="vcenterblock">
                               <div className="variant-message outdated-variant-message panel panel-danger">
                                   <div className="panel-body panel-danger">
-                                      <h3 style={{marginTop: 0}}>There is new data on this variant available.</h3>
+                                      <h3 style={{marginTop: 0}}>There is new data available on this variant.</h3>
 
                                       The data below is from release {variant.Data_Release.name} ({util.reformatDate(variant.Data_Release.date)}). <a href={`/variant/${data[0].id}`}>Click here for updated data on this variant.</a>
                                   </div>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -1121,9 +1121,9 @@ var VariantDetail = React.createClass({
                           <Col xs={12} classname="vcenterblock">
                               <div className="variant-message outdated-variant-message panel panel-danger">
                                   <div className="panel-body panel-danger">
-                                      <h3 style={{marginTop: 0}}>There is a newer version of this variant available</h3>
+                                      <h3 style={{marginTop: 0}}>There is new data on this variant available.</h3>
 
-                                      The data below is from release {variant.Data_Release.name}, dated {util.reformatDate(variant.Data_Release.date)}. <a href={`/variant/${data[0].id}`}>Go to the latest version of this variant.</a>
+                                      The data below is from release {variant.Data_Release.name} ({util.reformatDate(variant.Data_Release.date)}). <a href={`/variant/${data[0].id}`}>Click here for updated data on this variant.</a>
                                   </div>
                               </div>
                           </Col>
@@ -1135,12 +1135,11 @@ var VariantDetail = React.createClass({
                           <Col xs={12} classname="vcenterblock">
                               <div className="variant-message redirected-variant-msg panel panel-primary">
                                   <div className="panel-body panel-primary">
-                                      <h3 style={{marginTop: 0}}>You are now viewing the newest version of this variant</h3>
+                                      <h3 style={{marginTop: 0}}>You are viewing the most recent data on this variant.</h3>
 
-                                      The variant you originally requested was from an older release.
-                                      You have been automatically redirected to the newest version.<br />
+                                      The variant url you requested is from an old release. You have been automatically redirected to updated data. <br />
                                       <a href={`/variant/${redirectedFrom}?noRedirect=true`}>
-                                          Return to the version from release {redirectedFromVariant.Data_Release.name}, {util.reformatDate(redirectedFromVariant.Data_Release.date)}.
+                                          Click here to view variant data from Release {redirectedFromVariant.Data_Release.name} ({util.reformatDate(redirectedFromVariant.Data_Release.date)}).
                                       </a>
                                   </div>
                               </div>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -683,10 +683,11 @@ var VariantDetail = React.createClass({
             return <div />;
         }
 
-        let variant = data[0],
-            release = variant["Data_Release"],
-            cols,
-            groups;
+        const variantVersionIdx = data.findIndex(x => x.id === parseInt(this.props.params.id));
+        const variant = data[variantVersionIdx];
+        const release = variant["Data_Release"];
+        let cols, groups;
+
 
         if (this.props.mode === 'research_mode') {
             cols = researchModeColumns;

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -1212,7 +1212,7 @@ var VariantDetail = React.createClass({
 
                 <Row>
                     <Col md={12} className="variant-history-col">
-                        <h4>Previous Versions of this Variant (up to {util.reformatDate(data[0].Data_Release.date)}):</h4>
+                        <h4>Variant History:</h4>
                         <Table className='variant-history nopointer' responsive bordered>
                             <thead>
                                 <tr className='active'>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -1123,7 +1123,7 @@ var VariantDetail = React.createClass({
                                   <div className="panel-body panel-danger">
                                       <h3 style={{marginTop: 0}}>There is new data available on this variant.</h3>
 
-                                      The data below is from release {variant.Data_Release.name} ({util.reformatDate(variant.Data_Release.date)}). <a href={`/variant/${data[0].id}`}>Click here for updated data on this variant.</a>
+                                      The data below is from {util.reformatDate(variant.Data_Release.date)} (Release {variant.Data_Release.name}). <a href={`/variant/${data[0].id}`}>Click here for updated data on this variant.</a>
                                   </div>
                               </div>
                           </Col>
@@ -1137,9 +1137,9 @@ var VariantDetail = React.createClass({
                                   <div className="panel-body panel-primary">
                                       <h3 style={{marginTop: 0}}>You are viewing the most recent data on this variant.</h3>
 
-                                      The variant url you requested is from an old release. You have been automatically redirected to updated data. <br />
+                                      The variant url you requested only has data up to {util.reformatDate(redirectedFromVariant.Data_Release.date)}. You have been automatically redirected to the newest data.<br />
                                       <a href={`/variant/${redirectedFrom}?noRedirect=true`}>
-                                          Click here to view variant data from Release {redirectedFromVariant.Data_Release.name} ({util.reformatDate(redirectedFromVariant.Data_Release.date)}).
+                                          Click here to view variant data from {util.reformatDate(redirectedFromVariant.Data_Release.date)} (Release {redirectedFromVariant.Data_Release.name}).
                                       </a>
                                   </div>
                               </div>


### PR DESCRIPTION
This PR introduces a mechanism to automatically redirect the user to the newest version of a variant if they request an older version of the variant. The flow goes something like this:

1. The user requests an old version of a variant, e.g. http://localhost:8080/variant/9712
2. Upon request, the version's ID is compared to the newest one and if it's different, the user is redirected to the ID of the new variant with a querystring parameter appended that indicates a redirection occurred (e.g., http://localhost:8080/variant/222415?redirectedFrom=9712).
 - Note that the redirect *replaces* the current page in the history, since if we went back we would be immediately redirected forward.
3. On reaching the current version's page, a notice is displayed at the top of the page mentioning the redirect, with a link to return to the originally-requested version.
4. If the user clicks the link, they are returned to the previous version with '?noRedirect=true' specified to prevent them from being redirected again. In that case, the page instead displays a warning that the variant is not the newest version, and provides a link to the newest one. (e.g., http://localhost:8080/variant/9712?noRedirect=true).

Outside sources that wish to link to older variants intentionally may suppress the out-of-date warning by appending *both* 'noRedirect=true' and 'noRedirectMsg=true' to the query. If only 'noRedirectMsg=true' is specified, the redirect will still occur.

In summary, here are the possible querystring parameter configurations relating to redirects:
- **/variant/[id]:** redirection occurs normally
- **/variant/[id]?redirectedFrom=[old_id]:** notice is displayed that a redirect occurred.
- **/variant/[id]?noRedirect=true:** requested version is displayed even if it's out of date, but with a warning.
- **/variant/[id]?noRedirect=true&noRedirectMsg=true:** the requested version is displayed, with no warning indicating if it's out of date.
