### PR TITLE
hide report only clinvar fields from column selection in variants table

### DIFF
--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -136,9 +136,9 @@ const researchModeGroups = [
 
                 {title: 'Submission Type', prop: 'Method_ClinVar'},
                 {title: 'SCV Accession', prop: 'SCV_ClinVar'},
-                {title: 'Summary Evidence', prop: 'Summary_Evidence_ClinVar'},
-                {title: 'Supporting Observations', prop: 'Description_ClinVar'},
-                {title: 'Review Status', prop: 'Review_Status_ClinVar'},
+                {title: 'Summary Evidence', prop: 'Summary_Evidence_ClinVar', dummy: true},
+                {title: 'Supporting Observations', prop: 'Description_ClinVar', dummy: true},
+                {title: 'Review Status', prop: 'Review_Status_ClinVar', dummy: true},
             ]
         }
     },


### PR DESCRIPTION
Closes #1055 -- removes report only clinvar fields from column selection in variants table.

