### PR TITLE
Fixes reports newer than the current variant being returned

### DIFF
--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -125,7 +125,11 @@ def variant_reports(request, variant_id):
                 # if no key is available, skip report history
                 report_query = [report]
             else:
-                report_query = Report.objects.filter(SCV_ClinVar=key).order_by('-Data_Release_id').select_related('Data_Release')
+                # extend the selection w/reports that have matching keys,
+                # but only up until the requested variants' release
+                report_query = Report.objects\
+                    .filter(Data_Release_id__lte=report.Data_Release.id, SCV_ClinVar=key)\
+                    .order_by('-Data_Release_id').select_related('Data_Release')
             report_versions.extend(map(report_to_dict, report_query))
         elif report.Source == "LOVD":
             key = report.Submission_ID_LOVD
@@ -133,7 +137,11 @@ def variant_reports(request, variant_id):
                 # if no key is available, skip report history
                 report_query = [report]
             else:
-                report_query = Report.objects.filter(Submission_ID_LOVD=key).order_by('-Data_Release_id').select_related('Data_Release')
+                # extend the selection w/reports that have matching keys,
+                # but only up until the requested variants' release (i.e., same as for ClinVar)
+                report_query = Report.objects\
+                    .filter(Data_Release_id__lte=report.Data_Release.id, Submission_ID_LOVD=key)\
+                    .order_by('-Data_Release_id').select_related('Data_Release')
             report_versions.extend(map(report_to_dict, report_query))
 
     response = JsonResponse({"data": report_versions})


### PR DESCRIPTION
To explain  #1067, the "core reports" for a variant ID, i.e. the ones directly keyed to that variant's ID, were being returned correctly. The core reports are extended by a set of related reports (i.e., ones having the same SCV_ClinVar or Submission_ID_LOVD value, depending on the type of the report), but these reports were not constrained by a relationship with the variant ID (and thus implicitly constrained to be from the appropriate releases).

The fix is simply to gather related reports that are only as new as the release ID of the core report. I've done a little spot checking of the results, and it appears that reports are being returned only up to the release of the currently-viewed variant, as expected.