### PR TITLE
Display variant reps

### DIFF
--- a/website/django/data/urls.py
+++ b/website/django/data/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^variant/(?P<variant_id>.+)/reports$', views.variant_reports, name="variant_reports"),
     url(r'^variantcounts', views.variant_counts, name="variant_counts"),
     url(r'^variantpapers/$',views.variant_papers, name="variant_papers"),
-    url(r'^variantreps/$', views.variantreps, name="variant_reps"),
+    url(r'^variantreps', views.variantreps, name="variant_reps"),
     url(r'^suggestions/$', views.autocomplete),
     url(r'^ga4gh/v0.6.0a7/variants/search$', views.search_variants, name='search_variants'),
     url(r'^ga4gh/v0.6.0a7/variants/(?P<variant_id>.+)$', views.get_variant, name = 'get_variant'),

--- a/website/js/VariantRepresentations.js
+++ b/website/js/VariantRepresentations.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var React = require('react');
+var backend = require('./backend');
+
+
+var VariantRepresentations = React.createClass({
+    getInitialState: () => ({ data: {} }),
+    componentWillMount: function() {
+        console.log('here');
+        backend.variantReps().subscribe(
+            resp => this.setState(resp),
+            () => this.setState({error: 'Problem connecting to server'}));
+    },
+    render: function () {
+        // Ensure releases are in descending order
+        let representations = JSON.stringify(this.state.data);
+        return (
+            <div>
+                <h1 style={{ textAlign: 'center'}}>Variant Representations</h1>
+                <div style= {{ padding: '20px'}}>{representations}</div>
+            </div>
+        );
+    }
+});
+
+module.exports = ({
+    VariantRepresentations: VariantRepresentations,
+});

--- a/website/js/VariantRepresentations.js
+++ b/website/js/VariantRepresentations.js
@@ -7,13 +7,11 @@ var backend = require('./backend');
 var VariantRepresentations = React.createClass({
     getInitialState: () => ({ data: {} }),
     componentWillMount: function() {
-        console.log('here');
         backend.variantReps().subscribe(
             resp => this.setState(resp),
             () => this.setState({error: 'Problem connecting to server'}));
     },
     render: function () {
-        // Ensure releases are in descending order
         let representations = JSON.stringify(this.state.data);
         return (
             <div>

--- a/website/js/backend.js
+++ b/website/js/backend.js
@@ -78,6 +78,10 @@ function variantPapers(variant) {
     return Rx.DOM.get(`${config.backend_url}/data/variantpapers/?variant_id=${variant}`).map(xhr => JSON.parse(xhr.responseText));
 }
 
+function variantReps() {
+    return Rx.DOM.get(`${config.backend_url}/data/variantreps`).map(xhr => JSON.parse(xhr.responseText));
+}
+
 function variantCounts() {
     return Rx.DOM.get(`${config.backend_url}/data/variantcounts`).map(xhr => JSON.parse(xhr.responseText));
 }
@@ -118,6 +122,7 @@ module.exports = {
     variantReports,
     variantCounts,
     variantPapers,
+    variantReps,
     releases,
     release,
     users,

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -63,6 +63,7 @@ var VariantSearch = require('./VariantSearch');
 var {Navigation, State, Route, RouteHandler,
     HistoryLocation, run, DefaultRoute, Link} = require('react-router');
 var {Releases, Release} = require('./Releases.js');
+var {VariantRepresentations} = require('./VariantRepresentations.js');
 var Help = require('./Help.js');
 
 var KeyInline = require('./components/KeyInline');
@@ -1320,6 +1321,7 @@ var routes = (
         <Route path='variant_literature/:id' handler={LiteratureTable}/>
         <Route path='releases' handler={Releases}/>
         <Route path='release/:id' handler={Release}/>
+        <Route path='variantreps' handler={VariantRepresentations}/>
     </Route>
 );
 


### PR DESCRIPTION
Navigating to /variantreps now displays variant representations (extremely crude, for demo purposes)