### PR TITLE
ignore None type synonym values in clinvar

### DIFF
--- a/pipeline/clinvar/clinvar.py
+++ b/pipeline/clinvar/clinvar.py
@@ -56,7 +56,8 @@ def extractSynonyms(el):
         type = a.get('Type').lower()
         if type in include_types_norm or ('hgvs' in type and type
                                                not in exclude_hgvs_norm):
-            sy.append(a.text)
+            if a.text is not None:
+                sy.append(a.text)
 
     return sy + sy_alt
 


### PR DESCRIPTION
@izcram ClinVar parsing was ending prematurely because a None value was being inserted into the list of synonyms. I'm assuming if a.text is None it's safe to ignore that value as a synonym and move on, is this correct?

If not, could you dig in a little deeper and help us get this sorted? It's blocking pipeline runs at the moment.

Thanks!