### PR TITLE
Add search to VR API

### DIFF
--- a/website/content/help/research/help.md
+++ b/website/content/help/research/help.md
@@ -40,6 +40,7 @@ The Summary View contains an abridged view of the variant data in BRCA Exchange,
 * _Transcript Identifier_: These identifiers, which typically start in ‘NM’, are gene-specific, not variant-specific. They are generally used to keep track of different transcripts submitted to databases such as RefSeq, and are carried over to ClinVar. BRCA Exchange mainly uses contains two transcript identifiers. There is one main transcript used for _BRCA1_ \(NM 007294.3\) and another identifier used for _BRCA2_ \(NM 000059.3\). Other, less common transcripts are also present in the database.
 * _Abbreviated AA Change_: A shortened abbreviation of the HGVS Protein alias using one-letter abbreviation for amino acids.
 * _BIC designation_: A variant alias presented in BIC Nomenclature, which predates HGVS nomenclature and thus follows a different format.
+* _VRS Indentifier_: The VRS Identifier is a globally-unique identifier that removes a number of the ambiguities in variant representation. Further details are available [here](https://vr-spec.readthedocs.io/en/1.0/).
 
 #### Clinical Significance Tile
 

--- a/website/content/help/research/variant-nomenclature.md
+++ b/website/content/help/research/variant-nomenclature.md
@@ -57,3 +57,10 @@ A variant alias presented in BIC Nomenclature, which predates HGVS nomenclature 
 Link to the variant in the ClinGen Allele Registry.
 
 </span>
+
+<span class="term_entry">
+
+#### VRS Identifier ((VR_ID))
+The VRS Identifier is a globally-unique identifier that removes a number of the ambiguities in variant representation. Further details are available [here](https://vr-spec.readthedocs.io/en/1.0/).
+
+</span>

--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -111,9 +111,7 @@ def variant(request):
 def vrid(request):
     vr_id = request.GET.get('vr_id')
 
-    variant = Variant.objects.get(VR_ID__iexact=vr_id)
-    key = variant.Genomic_Coordinate_hg38
-    query = Variant.objects.filter(Genomic_Coordinate_hg38=key)\
+    query = Variant.objects.filter(VR_ID=vr_id)\
         .order_by('-Data_Release_id')\
         .select_related('Data_Release')\
         .select_related('Mupit_Structure')\
@@ -425,6 +423,10 @@ def apply_search(query, search_term, quotes='', release=None):
     search_term = search_term.lower().strip()
     search_term = remove_disallowed_chars(search_term)
     clinvar_accession = False
+
+    # Accept search by ga4gh VR id
+    if search_term.startswith('ga4gh'):
+        return query.filter(Q(VR_ID__icontains=search_term)), 0
 
     # Accept only full clinvar accession numbers
     if search_term.startswith('scv') and len(search_term) >= 12:

--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -111,14 +111,38 @@ def variant(request):
 def vrid(request):
     vr_id = request.GET.get('vr_id')
 
-    query = Variant.objects.filter(VR_ID=vr_id)\
-        .order_by('-Data_Release_id')\
-        .select_related('Data_Release')\
-        .select_related('Mupit_Structure')\
-        .select_related('insilicopriors')
+    variant = Variant.objects.filter(VR_ID=vr_id).order_by('-Data_Release_id')[0]
 
-    variant_versions = list(map(variant_to_dict, query))
-    response = JsonResponse({"data": variant_versions})
+    variant_data = variant_to_dict(variant)
+
+    relevant_keys = {
+        'id',
+        'Source',
+        'URL_ENIGMA',
+        'Condition_ID_type_ENIGMA',
+        'Condition_ID_value_ENIGMA',
+        'Condition_category_ENIGMA',
+        'Clinical_significance_ENIGMA',
+        'Date_last_evaluated_ENIGMA',
+        'Assertion_method_ENIGMA',
+        'Assertion_method_citation_ENIGMA',
+        'Clinical_significance_citations_ENIGMA',
+        'Comment_on_clinical_significance_ENIGMA',
+        'Collection_method_ENIGMA',
+        'Allele_origin_ENIGMA',
+        'ClinVarAccession_ENIGMA',
+        'Gene_Symbol',
+        'Reference_Sequence',
+        'HGVS_cDNA',
+        'BIC_Nomenclature',
+        'HGVS_Protein',
+        'Protein_Change',
+        'Genomic_HGVS_38',
+        'Genomic_HGVS_37',
+        'CA_ID'
+    }
+
+    response = JsonResponse({"data": {k: variant_data[k] for k in variant_data if k in relevant_keys}})
     response['Access-Control-Allow-Origin'] = '*'
     return response
 

--- a/website/js/VariantTable.js
+++ b/website/js/VariantTable.js
@@ -86,6 +86,7 @@ const researchModeGroups = [
         {title: 'Genome (GRCh37)', prop: 'Genomic_Coordinate_hg37'},
         {title: 'RNA (LOVD)', prop: 'RNA_LOVD'},
         {title: 'Beacons', core: true},
+        {title: 'VRS Indentifier', prop: 'VR_ID'},
         {title: 'Synonyms', prop: 'Synonyms'}
     ]},
 


### PR DESCRIPTION
Closes #1242 

1. Adds ability to search by VRS ID in the search bar.
2. Adds VRS ID to variant nomenclature tile in Detail View.
3. Fixes bug when querying by VRS id.
4. Limits response to only relevant data when querying by VRS id.