### PR TITLE
Removes gnomAD footnote in summary and details modes help text

### DIFF
--- a/website/content/help/default/how-is-the-data-on-this-site-updated.md
+++ b/website/content/help/default/how-is-the-data-on-this-site-updated.md
@@ -1,5 +1,2 @@
-BRCA Exchange is updated through monthly data releases. These releases utilize an automated pipeline that retrieve the most recent information available from source databases, which include 1000 Genomes, BIC, ClinVar, ESP, ExAC\*, ExUV, LOVD, and ENIGMA. [Release Notes](https://brcaexchange.org/release/12) are available for each data release. The release notes are available for each release date, and include data summaries on new variants, removed variants, new classifications, and known issues. The software used for each release is open source, and available at
+BRCA Exchange is updated through monthly data releases. These releases utilize an automated pipeline that retrieve the most recent information available from source databases, which include 1000 Genomes, BIC, ClinVar, ESP, gnomAD, ExAC, ExUV, LOVD, and ENIGMA. [Release Notes](https://brcaexchange.org/release/12) are available for each data release. The release notes are available for each release date, and include data summaries on new variants, removed variants, new classifications, and known issues. The software used for each release is open source, and available at
 [https://github.com/BRCAChallenge/brca-exchange/commit/8d436ee6a7b13831b7bbd5bf4e7426abe52aa923](https://github.com/BRCAChallenge/brca-exchange/commit/8d436ee6a7b13831b7bbd5bf4e7426abe52aa923)
-
-\*gnomAD data coming soon
-

--- a/website/content/help/research/how-is-the-data-on-this-site-updated.md
+++ b/website/content/help/research/how-is-the-data-on-this-site-updated.md
@@ -1,5 +1,2 @@
-BRCA Exchange is updated through monthly data releases. These releases utilize an automated pipeline that retrieve the most recent information available from source databases, which include 1000 Genomes, BIC, ClinVar, ESP, ExAC\*, ExUV, LOVD, and ENIGMA. [Release Notes](https://brcaexchange.org/release/12) are available for each data release. The release notes are available for each release date, and include data summaries on new variants, removed variants, new classifications, and known issues. The software used for each release is open source, and available at
+BRCA Exchange is updated through monthly data releases. These releases utilize an automated pipeline that retrieve the most recent information available from source databases, which include 1000 Genomes, BIC, ClinVar, ESP, gnomAD, ExAC, ExUV, LOVD, and ENIGMA. [Release Notes](https://brcaexchange.org/release/12) are available for each data release. The release notes are available for each release date, and include data summaries on new variants, removed variants, new classifications, and known issues. The software used for each release is open source, and available at
 [https://github.com/BRCAChallenge/brca-exchange/commit/8d436ee6a7b13831b7bbd5bf4e7426abe52aa923](https://github.com/BRCAChallenge/brca-exchange/commit/8d436ee6a7b13831b7bbd5bf4e7426abe52aa923)
-
-\*gnomAD data coming soon
-


### PR DESCRIPTION
 Removes gnomAD footnote from 'how is the data on the site updated' help text section, in both summary and details modes. Closes issue #1247.