### PR TITLE
Gnomad download disparity fix

### DIFF
--- a/pipeline/clinvar/enigma_from_clinvar.py
+++ b/pipeline/clinvar/enigma_from_clinvar.py
@@ -2,7 +2,6 @@ import copy
 import itertools
 import logging
 import re
-import logging
 import click
 import pandas as pd
 from lxml import etree

--- a/pipeline/gnomad/download_gnomad_data.py
+++ b/pipeline/gnomad/download_gnomad_data.py
@@ -5,6 +5,7 @@ import time
 import numpy as np
 import pandas as pd
 import argparse
+import logging
 from math import floor, log10, isnan
 
 
@@ -175,6 +176,7 @@ def fetch_data_for_one_variant(variant_id, dataset, max_retries=5):
                 parse = json.loads(response.text)
         except json.decoder.JSONDecodeError:
             retries += 1
+            logging.warning(f'Request for variant {variant_id} failed, kicking off retry #{retries}')
             time.sleep(0.1)
         else:
             return(parse['data']['variant'])
@@ -282,12 +284,16 @@ def find_correct_hgvs(variants, transcripts):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--output', help='Ouput tsv file result.')
+    parser.add_argument('-l', '--logfile', help='Ouput logfile.')
     options = parser.parse_args()
     return options
 
 
 def main():
     f_out = parse_args().output
+    log_file_path = parse_args().logfile
+    logging.basicConfig(filename=log_file_path, filemode="w",
+                        format=' %(asctime)s %(filename)-15s %(message)s')
     dataset = "gnomad_r2_1_non_cancer"
     brca1_transcript ="ENST00000357654"
     brca2_transcript = "ENST00000544455"

--- a/pipeline/workflow/gnomad_processing.py
+++ b/pipeline/workflow/gnomad_processing.py
@@ -33,7 +33,7 @@ class DownloadGnomADData(GnomADTask):
     def run(self):
         os.chdir(gnomAD_method_dir)
 
-        args = ["python", "download_gnomad_data.py", "-o", self.output().path]
+        args = ["python", "download_gnomad_data.py", "-o", self.output().path, "-l", self.artifacts_dir + "/gnomAD_download.log"]
 
         pipeline_utils.run_process(args)
         pipeline_utils.check_file_for_contents(self.output().path)

--- a/pipeline/workflow/gnomad_processing.py
+++ b/pipeline/workflow/gnomad_processing.py
@@ -26,6 +26,28 @@ class GnomADTask(DefaultPipelineTask):
 
 
 class DownloadGnomADData(GnomADTask):
+    gnomAD_static_data_url = luigi.Parameter(default='https://brcaexchange.org/backend/downloads/gnomAD_static_download_10_02_2020.tsv',
+                                            description='URL to download static gnomAD data from')
+
+    def output(self):
+        return luigi.LocalTarget(self.assays_dir + "/gnomAD.tsv")
+
+    def run(self):
+        data = pipeline_utils.urlopen_with_retry(self.gnomAD_static_data_url).read()
+        with open(self.output().path, "wb") as f:
+            f.write(data)
+
+"""
+################
+NOTE:
+gnomAD rarely updates its dataset
+due to issues with consistency downloading the same gnomad data for each release,
+a static file can be reused until new data is available
+see previous task for static data download
+################
+
+
+class DownloadGnomADData(GnomADTask):
     def output(self):
         return luigi.LocalTarget(
             os.path.join(self.gnomAD_file_dir, self.gnomAD_download_file))
@@ -37,6 +59,7 @@ class DownloadGnomADData(GnomADTask):
 
         pipeline_utils.run_process(args)
         pipeline_utils.check_file_for_contents(self.output().path)
+"""
 
 
 @requires(DownloadGnomADData)


### PR DESCRIPTION
this PR does two things:

1. adds logging to the download gnomad script
2. disables the download gnomad script temporarily and reuses static data instead

when new data is available we can adjust the download script accordingly
this ensures we'll always get the same complete gnomad dataset from gnomad as long as their data remains the same