### PR TITLE
Moved the splice AI output VCF file from the discard list to the keep…

### DIFF
--- a/pipeline/workflow/tarball_files_discard_list.txt
+++ b/pipeline/workflow/tarball_files_discard_list.txt
@@ -5,7 +5,6 @@
 ./release/artifacts/bayesdel.vcf
 ./release/artifacts/BICready.vcf
 ./release/artifacts/BIC.vcf
-./release/artifacts/variants_with_splice_ai.vcf
 ./release/artifacts/built.tsv
 ./release/artifacts/built_with_bayesdel.tsv
 ./release/artifacts/built_with_spliceai.tsv

--- a/pipeline/workflow/tarball_files_keep_list.txt
+++ b/pipeline/workflow/tarball_files_keep_list.txt
@@ -22,6 +22,7 @@
 ./release/artifacts/missing_reports.log
 ./release/artifacts/reports.tsv
 ./release/artifacts/variant_merging.log
+./release/artifacts/variants_with_splice_ai.vcf
 ./release/artifacts/victor_annotation.log
 ./release/artifacts/wrong_genome_coors/1000_Genomes_wrong_genome_coor.vcf
 ./release/artifacts/wrong_genome_coors/BIC_wrong_genome_coor.vcf


### PR DESCRIPTION
… list, so it will be available in the future for automating spliceAI by computing on only the new variants