### PR TITLE
Fix #1433: Updates Google Analytics to GA4 and removes react-ga dependency

### DIFF
--- a/website/js/index.js
+++ b/website/js/index.js
@@ -80,12 +80,6 @@ if (typeof console === "undefined") {
     };
 }
 
-// add react-ga tracking code to track each pageview
-import ReactGA from 'react-ga';
-if (window.config.analytics) {
-    ReactGA.initialize(window.config.analytics, { standardImplementation: true });
-}
-
 function isEmptyVal(val) {
     if ((typeof val === 'string' || val instanceof String) && val.trim() === '') {
             return true;
@@ -828,6 +822,7 @@ var VariantDetail = React.createClass({
             return <div />;
         }
 
+
         const variantVersionIdx = data.findIndex(x => x.id === parseInt(this.props.params.id));
         const variant = data[variantVersionIdx] || data[0];
         const release = variant["Data_Release"];
@@ -1456,15 +1451,6 @@ var Application = React.createClass({
     },
     render: function () {
         const path = this.getPath().slice(1);
-
-        // logs the full path, including the hash, to google analytics (if analytics is enabled)
-        if (window.config.analytics) {
-            const fullHref = window.location.href;
-            const origin = window.location.origin;
-            const fullPathWithHash = fullHref.startsWith(origin) ? fullHref.slice(origin.length) : fullHref;
-            ReactGA.ga('send', 'pageview', fullPathWithHash);
-        }
-
         return (
             <div>
                 <NavBarNew path={path} mode={this.state.mode} toggleMode={this.toggleMode}/>

--- a/website/package.json
+++ b/website/package.json
@@ -74,7 +74,6 @@
     "react-bootstrap": "^0.33.1",
     "react-data-components-brcaex": "^0.5.6",
     "react-dom": "^0.14.8",
-    "react-ga": "^2.5.7",
     "react-remarkable": "^1.1.1",
     "react-router": "^0.13.3",
     "rx": "^2.4.3",

--- a/website/page.template
+++ b/website/page.template
@@ -26,6 +26,26 @@
                 };
             })();
         </script>
+
+        <!-- Google tag (gtag.js) -->
+        <script>
+            if (window.config.analytics) {
+                var conditionalGTag = document.createElement("script");
+                conditionalGTag.setAttribute("async", "");
+                conditionalGTag.src = "https://www.googletagmanager.com/gtag/js?id=" + window.config.analytics ;
+                document.getElementsByTagName('head')[0].appendChild(conditionalGTag);
+            }
+            else { console.log("Google Analytics disabled."); }
+        </script>
+        <script>
+            if (window.config.analytics) {
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', window.config.analytics);
+            }
+        </script>
+
 		<script src='https://www.google.com/recaptcha/api.js?onload=recaptchaCallback&render=explicit' async defer></script>
         <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 	    <!-- Favicon and touch icons -->
@@ -47,17 +67,6 @@
 	    <meta name="msapplication-TileColor" content="#00aba9">
 	    <meta name="msapplication-TileImage" content="favicon/mstile-144x144.png">
 	    <meta name="theme-color" content="#ffffff">
-	    <script>
-			if (window.config.analytics) {
-				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-				ga('create', window.config.analytics, 'auto');
-				ga('send', 'pageview');
-			}
-	    </script>
 	</head>
 	<body id="body">
 		<div id="main"></div>


### PR DESCRIPTION
Fixes issue #1433 

- Removes react-ga module and related code; the react-ga module does not support GA4.
- Instead, loads google analytics code via page.template
- For Google Analytics to activate, the config.analytics entry must be set in config.js to the Google Analytics 4 tag in use such as "G-xxxxxxxxxx". (Might work with the older UA-xxx tags but not sure.)

eg
```
module.exports = {
    captcha_key: '', /* enter captch key here */
    backend_url: 'http://brcaexchange.org/backend',
    analytics: 'G-xxxxxxxxxx',
    environment: 'production'
};
```