### PR TITLE
Attempt to fix "deploy-dev" script breaking in CI by forcing rsync to use ipv4

### DIFF
--- a/deployment/deploy-dev
+++ b/deployment/deploy-dev
@@ -13,8 +13,9 @@ cd ${WEBSITE}
 npm run build:prod
 
 # deploy (not preserving owner/group)
-rsync -rlptD --delete --rsync-path='rsync' build/ ${USER}@${HOST}:/var/www/html/beta
-rsync -rlptD --delete --exclude="/uploads" --exclude="/downloads/*" --rsync-path='rsync' django/ ${USER}@${HOST}:/var/www/backend/beta/django
+# Force rsync's ssh to use ipv4 to prevent "Cannot assign requested address" error
+rsync -rlptD -e 'ssh -4' --delete --rsync-path='rsync' build/ ${USER}@${HOST}:/var/www/html/beta
+rsync -rlptD -e 'ssh -4' --delete --exclude="/uploads" --exclude="/downloads/*" --rsync-path='rsync' django/ ${USER}@${HOST}:/var/www/backend/beta/django
 
 requirements=$(cat requirements.txt)
 requirements=$(echo ${requirements}) # drop carriage returns


### PR DESCRIPTION
an attempt to fix [this error](https://app.circleci.com/pipelines/github/BRCAChallenge/brca-exchange/1373/workflows/3e3c41d9-21b1-4514-bcd8-ed2d752ce7d5/jobs/9528) in the continuous integration script 'deploy-dev':

`ssh: connect to host brcaexchange-dev.gi.ucsc.edu port 22: Cannot assign requested address
rsync error: unexplained error (code 255) at log.c(245) [sender=3.1.3]`

I can reproduce it by forcing rsync to use ipv6:

```
rsync -e 'ssh -6' myfile user@brcaexchange-dev.gi.ucsc.edu:/destination
ssh: connect to host brcaexchange-dev.gi.ucsc.edu port 22: Cannot assign requested address
rsync error: unexplained error (code 255) at log.c(245) [sender=3.1.3]`
```
And  from some servers, pinging `brcaexchange-dev.gi.ucsc.edu` defaults to ipv6. 

So, I believe that forcing rsync to use ipv4 from the CI will fix it. Therefore I've added `-e 'ssh -4'` to the two rsync lines in `deploy-dev`.