### PR TITLE
Small changes re: provisional evidence

### DIFF
--- a/deployment/site_settings/config.beta.js
+++ b/deployment/site_settings/config.beta.js
@@ -5,7 +5,7 @@
         baseurl: '/',
         captcha_key: '', /* reCAPTCHA API key */
         maps_key: '', /* Google maps javascript API key */
-        backend_url: 'http://brcaexchange-prod.gi.ucsc.edu/backend',
+        backend_url: 'https://brcaexchange-prod.gi.ucsc.edu/backend',
         analytics: null,
         environment: 'beta'
     };

--- a/website/js/components/DonationBar.js
+++ b/website/js/components/DonationBar.js
@@ -9,7 +9,7 @@ const DonationBar = React.createClass({
         return (
         	<div className="donation-bar">
     			<p>
-                We are pleased to introduce a new feature: persistent URLs for the variants in BRCA Exchange!  More information is available <a style={{textDecoration: 'underline'}} href="https://brcaexchange.org/blog/index.php/2024/02/01/new-feature-persistent-urls-for-brca-exchange-variants/">here</a> on the BRCA Exchange blog.
+                We are excited to introduce provisional assignments of the ACMG evidence codes for all variants in BRCA Exchange!  Please see our <a style={{textDecoration: 'underline'}} href="https://brcaexchange.org/blog/index.php/2024/08/14/new-feature-acmg-evidence-code-provisional-assignments/">latest blog post</a> for more information
 	        	</p>
         	</div>
         );

--- a/website/js/components/ProvisionalEvidenceTile.js
+++ b/website/js/components/ProvisionalEvidenceTile.js
@@ -55,6 +55,11 @@ export default class ProvisionalEvidenceTile extends React.Component {
             let groupData = group.data;
             let renderedRows = this.getRowsAndDetermineIfEmpty(groupSource, groupData, variant);
 
+            // TEMPORARY - hide ComputationalPrediction subsection until data is populated
+            if (groupSource === "Computational Prediction") {
+                return ( <div id={groupSource}/> );
+            }
+
             // Attempt to retrieve the prop name of the provisional code so we can put the value in the subsection header
             let extraHeaderProp = false ;
             for ( const dataItem of groupData ) {


### PR DESCRIPTION
- config file template fix to allow the beta backend to operate over https
- new donation bar advertising the [blog post ](https://brcaexchange.org/blog/index.php/2024/08/14/new-feature-acmg-evidence-code-provisional-assignments/)
- hide the computational prediction subtile until data is populated